### PR TITLE
Start adding spec-compliant types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,21 +10,22 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "atty"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -61,8 +62,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.5.2"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bytes"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "c2-chacha"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cc"
@@ -80,12 +98,20 @@ version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -101,11 +127,14 @@ name = "cookie"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "devise"
@@ -142,11 +171,74 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "dtoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "eth2_hashing"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "eth2_ssz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "eth2_ssz_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethbloom 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethereum-types-serialize"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ewasm"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-builder 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -162,6 +254,30 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -185,6 +301,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -236,9 +357,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "heapsize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "heck"
@@ -250,11 +389,16 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hex"
@@ -276,7 +420,7 @@ dependencies = [
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -291,20 +435,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rlp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -318,6 +478,15 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "int_to_bytes"
+version = "0.1.0"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -349,6 +518,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -360,6 +534,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libc"
 version = "0.2.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -390,7 +569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -426,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "mio-extras"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -458,19 +637,18 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "4.0.14"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fsevent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fsevent-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "inotify 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inotify 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -489,55 +667,55 @@ dependencies = [
  "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "snafu 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-rational"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -573,7 +751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -582,13 +760,32 @@ version = "0.1.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "proc-macro-error"
+name = "ppv-lite86"
 version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro-error"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-error-attr 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn-mid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -639,19 +836,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ring"
-version = "0.13.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rlp"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -659,11 +936,11 @@ name = "rocket"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -680,7 +957,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "devise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -693,10 +970,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "notify 4.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -706,13 +983,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustversion"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -727,10 +1019,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "same-file"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -752,8 +1044,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_hex"
+version = "0.1.0"
+dependencies = [
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_json"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -762,8 +1062,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "slog"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -776,21 +1092,21 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "snafu"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "snafu-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu-derive 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -799,8 +1115,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ssz_types"
+version = "0.1.0"
+dependencies = [
+ "eth2_ssz 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_hex 0.1.0",
+ "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "state"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "static_assertions"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -810,20 +1155,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "structopt-derive"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -850,11 +1196,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-mid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -868,20 +1237,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "0.2.2"
+name = "tiny-keccak"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-macros 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -902,6 +1279,25 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "tree_hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "eth2_hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tree_hash_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typeable"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +1310,43 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "typenum"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "types"
+version = "0.1.0"
+dependencies = [
+ "eth2_ssz 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "int_to_bytes 0.1.0",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssz_types 0.1.0",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -934,10 +1367,10 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -947,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -997,7 +1430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1013,13 +1446,18 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.2.9"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasmi"
@@ -1028,8 +1466,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi-validation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1068,7 +1506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1089,6 +1527,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "yansi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,118 +1546,164 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
-"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
-"checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum bytes 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c85319f157e4e26c703678e68e26ab71a46c0199286fa670b21cc9fec13d895"
+"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 "checksum cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "99be24cfcf40d56ed37fd11c2123be833959bbc5bddecb46e1c2e442e15fa3e0"
+"checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum devise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e04ba2d03c5fa0d954c061fc8c9c288badadffc272ebb87679a89846de3ed3"
 "checksum devise_codegen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "066ceb7928ca93a9bedc6d0e612a8a0424048b0ab1f75971b203d01420c055d7"
 "checksum devise_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf41c59b22b5e3ec0ea55c7847e5f358d340f3a8d6d53a5cf4f1564967f96487"
 "checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
+"checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
+"checksum eth2_hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7f8c469f2edea348a9e715d46e48112a62ba7b588344e349e789fed01751fae"
+"checksum eth2_ssz 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5785a82b7bf7c817e2648d0159a0df29b16c2314e039b9789acc9643db86ab0a"
+"checksum eth2_ssz_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a65c8ff9cc6c51a212e6a649f8de2704b2ac0bac2e178ecf1ac7db591e9865"
+"checksum ethbloom 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
+"checksum ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b054df51e53f253837ea422681215b42823c02824bde982699d0dceecf6165a1"
+"checksum ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1873d77b32bc1891a79dad925f2acbc318ee942b38b9110f9dbc5fbeffcea350"
 "checksum ewasm 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4caf4630b89428457486356ea4896c236b7cc5efb37f42c8a2b85d695a27ccfe"
 "checksum filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
+"checksum fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a683d1234507e4f3bf2736eeddf0de1dc65996dc0164d57eba0a74bcf29489"
+"checksum fixed-hash 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fsevent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
 "checksum fsevent-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
 "checksum futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
 "checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
 "checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
+"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
+"checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
+"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-"checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
-"checksum inotify 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40b54539f3910d6f84fbf9a643efd6e3aa6e4f001426c0329576128255994718"
+"checksum impl-rlp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+"checksum impl-serde 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
+"checksum indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc"
+"checksum inotify 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8"
 "checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+"checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+"checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
-"checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
+"checksum mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-"checksum notify 4.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "199628fc33b21bc767baa057490b00b382ecbae030803a7b36292422d15b778b"
-"checksum num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9c3f34cdd24f334cb265d9bf8bfa8a241920d026916785747a92f0e55541a1a"
-"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
-"checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
-"checksum num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
-"checksum num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
+"checksum notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
+"checksum num-bigint 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f115de20ad793e857f76da2563ff4a09fbcfd6fe93cca0c5d996ab5f3ee38d"
+"checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+"checksum num-rational 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "da4dc79f9e6c81bef96148c8f6b8e72ad4541caa4a24373e900a36da07de03a3"
+"checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+"checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1e39faaa292a687ea15120b1ac31899b13586446521df6c149e46f1584671e0f"
 "checksum pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c26d2b92e47063ffce70d3e3b1bd097af121a9e0db07ca38a6cc1cf0cc85ff25"
 "checksum pear_codegen 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "336db4a192cc7f54efeb0c4e11a9245394824cc3bcbd37ba3ff51240c35d7a6e"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991"
+"checksum pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
-"checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
+"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+"checksum proc-macro-error 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1b79a464461615532fcc8a6ed8296fa66cc12350c18460ab3f4594a6cee0fcb6"
+"checksum proc-macro-error-attr 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "23832e5eae6bac56bbac190500eef1aaede63776b5cd131eaa4ee7fe120cd892"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
+"checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+"checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
+"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+"checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
+"checksum rlp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3a44d5ae8afcb238af8b75640907edc6c931efcfab2c854e81ed35fa080f84cd"
 "checksum rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "42c1e9deb3ef4fa430d307bfccd4231434b707ca1328fae339c43ad1201cc6f7"
 "checksum rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "79aa1366f9b2eccddc05971e17c5de7bb75a5431eb12c2b5c66545fd348647f4"
 "checksum rocket_contrib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e0fa5c1392135adc0f96a02ba150ac4c765e27c58dbfd32aa40678e948f6e56f"
 "checksum rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1391457ee4e80b40d4b57fa5765c0f2836b20d73bcbee4e3f35d93cf3b80817"
+"checksum rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+"checksum rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-"checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
+"checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
 "checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
-"checksum serde_json 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "7406489f3d6d6633ea32abb80dede59df6e3d1a6fdd6e867db84bbaff3c7d079"
+"checksum serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "eab8f15f15d6c41a154c1b128a22f2dfabe350ef53c40953d84e36155c91192b"
+"checksum serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+"checksum slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-"checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
-"checksum snafu 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41207ca11f96a62cd34e6b7fdf73d322b25ae3848eb9d38302169724bb32cf27"
-"checksum snafu-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5e338c8b0577457c9dda8e794b6ad7231c96e25b1b0dd5842d52249020c1c0"
+"checksum smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
+"checksum snafu 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "546db9181bce2aa22ed883c33d65603b76335b4c2533a98289f54265043de7a1"
+"checksum snafu-derive 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bdc75da2e0323f297402fd9c8fdba709bb04e4c627cbe31d19a2c91fc8d9f0e2"
+"checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
+"checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
+"checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "30b3a3e93f5ad553c38b3301c8a0a0cec829a36783f6a0c467fc4bf553a5f5bf"
-"checksum structopt-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
+"checksum structopt 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "df136b42d76b1fbea72e2ab3057343977b04b4a2e00836c3c7c0673829572713"
+"checksum structopt-derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd50a87d2f7b8958055f3e73a963d78feaccca3836767a9069844e34b5b03c0a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
+"checksum syn-mid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd3937748a7eccff61ba5b90af1a20dbf610858923a9192ea0ecb0cb77db1d0"
+"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum tokio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e765bf9f550bd9b8a970633ca3b56b8120c4b6c5dcbe26a93744cb02fee4b17"
-"checksum tokio-macros 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5795a71419535c6dcecc9b6ca95bdd3c2d6142f7e8343d7beb9923f129aa87e"
+"checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+"checksum tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c1fc73332507b971a5010664991a441b5ee0de92017f5a0e8b00fd684573045b"
+"checksum tokio-macros 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "50a61f268a3db2acee8dcab514efc813dc6dbe8a00e86076f935f94304b59a7a"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+"checksum tree_hash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "61947bffe22c5f27c568833c639517a4443dc92002f9c14ecbef31d4871f82d4"
+"checksum tree_hash_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81caa5deb141403cfc4227091c58bfeb231f87edcbe60b88dbae20581b6f22a4"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typed-builder 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7e38507a437aef3b8ead39616219615ff9320d0eb0907f0dce51ea0474889cc6"
+"checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum uint 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "082df6964410f6aa929a61ddfafc997e4f32c62c22490e439ac351cec827f436"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
+"checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
@@ -1221,15 +1713,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3c5c5c1286c6e578416982609f47594265f9d489f9b836157d403ad605a46693"
 "checksum wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af5d153dc96aad7dc13ab90835b892c69867948112d95299e522d370c4e13a08"
-"checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
+"checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f31d26deb2d9a37e6cfed420edce3ed604eab49735ba89035e13c98f9a528313"
 "checksum wasmi-validation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6bc0356e3df56e639fc7f7d8a99741915531e27ed735d911ed83d7e1339c8188"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
+"checksum winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d60c3b48c9cdec42fb06b3b84b5b087405e1fa1c644a1af3930e4dfafe93de48"
 "checksum yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 members = [
+    "eth2/types",
+    "eth2/utils/int_to_bytes",
+    "eth2/utils/ssz_types",
     'notion-cli',
     'notion-server',
 ]

--- a/eth2/types/Cargo.toml
+++ b/eth2/types/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "types"
+version = "0.1.0"
+authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+eth2_ssz = "0.1.2"
+eth2_ssz_derive = "0.1.0"
+fixed-hash = "0.5.2"
+hex = "0.3"
+int_to_bytes = { path = "../utils/int_to_bytes" }
+rand = "0.7.2"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.45"
+slog = "2.5.2"
+ssz_types = { path = "../utils/ssz_types" }
+tree_hash = "0.1.0"
+tree_hash_derive = "0.1"
+typenum = "1.11.2"
+
+[dev-dependencies]
+serde_yaml = "0.8.11"
+tempfile = "3.1.0"

--- a/eth2/types/Cargo.toml
+++ b/eth2/types/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 eth2_ssz = "0.1.2"
 eth2_ssz_derive = "0.1.0"

--- a/eth2/types/src/beacon_state.rs
+++ b/eth2/types/src/beacon_state.rs
@@ -1,0 +1,93 @@
+// Makes heavy use of patterns and code found in sigp/lighthouse
+use crate::cross_link::{CrossLink};
+use crate::eth_spec::EthSpec;
+use crate::execution_environment::{ExecutionEnvironment};
+use crate::newtypes::{Root, Slot};
+use serde::{Deserialize, Serialize};
+use serde_json;
+use ssz::{Decode, Encode};
+use ssz_derive::{Decode as DeriveDecode, Encode as DeriveEncode};
+use ssz_types::{BitVector, FixedVector, VariableList};
+
+/// The state of the `BeaconChain` at some slot.
+/// Full spec is here: https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#beaconstate
+/// SSZ spec is here: https://github.com/ethereum/eth2.0-specs/blob/dev/ssz/simple-serialize.md
+
+#[derive(
+Debug,
+PartialEq,
+Clone,
+Deserialize,
+Serialize,
+DeriveDecode,
+DeriveEncode,
+)]
+#[serde(bound = "T: EthSpec")]
+pub struct BeaconState<T>
+    where
+        T: EthSpec,
+{
+    // Versioning
+//    genesis_time: u64,
+    slot: Slot,
+//    fork: Fork,
+
+    // History
+//    latest_block_header: BeaconBlockHeader,
+//    block_roots: FixedVector<Root, T::SlotsPerHistoricalRoot>,
+//    state_roots: FixedVector<Root, T::SlotsPerHistoricalRoot>,
+//    historical_roots: VariableList<Root, T::HistoricalRootsLimit>,
+
+    // Eth1
+//    eth1_data: Eth1Data,
+//    eth1_data_votes: VariableList<Eth1Data, T::ValidatorRegistryLimit>,
+//    eth1_deposit_index: u64,
+
+    // Registry
+//    validators: VariableList<Validator, T::ValidatorRegistryLimit>,
+//    balances: VariableList<Gwei, T::ValidatorRegistryLimit>,
+
+    // Randomness
+//    randao_mixes: FixedVector<Gwei, T::EpochsPerHistoricalVector>,
+
+    // Slashings
+//    slashings: FixedVector<Gwei, T::EpochsPerSlashingsVector>,
+
+    // Attestations
+//    previous_epoch_attestations: VariableList<PendingAttestation, T::MaxPendingAttestations>,
+
+    // Finality
+//    justification_bits: BitVector<T::JustificationBitsLength>,
+//    previous_justified_checkpoint: Checkpoint,
+//    current_justified_checkpoint: Checkpoint,
+//    finalized_checkpoint: Checkpoint,
+
+    // Unspecced fields
+    cross_links: FixedVector<CrossLink, T::ShardCount>,
+    execution_environments: VariableList<ExecutionEnvironment, T::MaxExecutionEnvironments>,
+
+}
+
+impl<T: EthSpec> BeaconState<T> {
+    fn new() -> Self {
+        Self {
+            slot: Slot::new(0),
+            cross_links: FixedVector::from_elem(CrossLink::default()),
+            execution_environments: VariableList::empty(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eth_spec::MainnetEthSpec;
+
+    #[test]
+    fn can_encode_and_decode_ssz() {
+        let original: BeaconState<MainnetEthSpec> = BeaconState::new();
+        let serialized: Vec<u8> = original.as_ssz_bytes();
+        let deserialized: BeaconState<MainnetEthSpec> = BeaconState::from_ssz_bytes(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+}

--- a/eth2/types/src/beacon_state.rs
+++ b/eth2/types/src/beacon_state.rs
@@ -1,7 +1,7 @@
 // Makes heavy use of patterns and code found in sigp/lighthouse
-use crate::cross_link::{CrossLink};
+use crate::cross_link::CrossLink;
 use crate::eth_spec::EthSpec;
-use crate::execution_environment::{ExecutionEnvironment};
+use crate::execution_environment::ExecutionEnvironment;
 use crate::newtypes::{Root, Slot};
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -13,59 +13,50 @@ use ssz_types::{BitVector, FixedVector, VariableList};
 /// Full spec is here: https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#beaconstate
 /// SSZ spec is here: https://github.com/ethereum/eth2.0-specs/blob/dev/ssz/simple-serialize.md
 
-#[derive(
-Debug,
-PartialEq,
-Clone,
-Deserialize,
-Serialize,
-DeriveDecode,
-DeriveEncode,
-)]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize, DeriveDecode, DeriveEncode)]
 #[serde(bound = "T: EthSpec")]
 pub struct BeaconState<T>
-    where
-        T: EthSpec,
+where
+    T: EthSpec,
 {
     // Versioning
-//    genesis_time: u64,
+    //    genesis_time: u64,
     slot: Slot,
-//    fork: Fork,
+    //    fork: Fork,
 
     // History
-//    latest_block_header: BeaconBlockHeader,
-//    block_roots: FixedVector<Root, T::SlotsPerHistoricalRoot>,
-//    state_roots: FixedVector<Root, T::SlotsPerHistoricalRoot>,
-//    historical_roots: VariableList<Root, T::HistoricalRootsLimit>,
+    //    latest_block_header: BeaconBlockHeader,
+    //    block_roots: FixedVector<Root, T::SlotsPerHistoricalRoot>,
+    //    state_roots: FixedVector<Root, T::SlotsPerHistoricalRoot>,
+    //    historical_roots: VariableList<Root, T::HistoricalRootsLimit>,
 
     // Eth1
-//    eth1_data: Eth1Data,
-//    eth1_data_votes: VariableList<Eth1Data, T::ValidatorRegistryLimit>,
-//    eth1_deposit_index: u64,
+    //    eth1_data: Eth1Data,
+    //    eth1_data_votes: VariableList<Eth1Data, T::ValidatorRegistryLimit>,
+    //    eth1_deposit_index: u64,
 
     // Registry
-//    validators: VariableList<Validator, T::ValidatorRegistryLimit>,
-//    balances: VariableList<Gwei, T::ValidatorRegistryLimit>,
+    //    validators: VariableList<Validator, T::ValidatorRegistryLimit>,
+    //    balances: VariableList<Gwei, T::ValidatorRegistryLimit>,
 
     // Randomness
-//    randao_mixes: FixedVector<Gwei, T::EpochsPerHistoricalVector>,
+    //    randao_mixes: FixedVector<Gwei, T::EpochsPerHistoricalVector>,
 
     // Slashings
-//    slashings: FixedVector<Gwei, T::EpochsPerSlashingsVector>,
+    //    slashings: FixedVector<Gwei, T::EpochsPerSlashingsVector>,
 
     // Attestations
-//    previous_epoch_attestations: VariableList<PendingAttestation, T::MaxPendingAttestations>,
+    //    previous_epoch_attestations: VariableList<PendingAttestation, T::MaxPendingAttestations>,
 
     // Finality
-//    justification_bits: BitVector<T::JustificationBitsLength>,
-//    previous_justified_checkpoint: Checkpoint,
-//    current_justified_checkpoint: Checkpoint,
-//    finalized_checkpoint: Checkpoint,
+    //    justification_bits: BitVector<T::JustificationBitsLength>,
+    //    previous_justified_checkpoint: Checkpoint,
+    //    current_justified_checkpoint: Checkpoint,
+    //    finalized_checkpoint: Checkpoint,
 
     // Unspecced fields
     cross_links: FixedVector<CrossLink, T::ShardCount>,
     execution_environments: VariableList<ExecutionEnvironment, T::MaxExecutionEnvironments>,
-
 }
 
 impl<T: EthSpec> BeaconState<T> {
@@ -87,7 +78,8 @@ mod tests {
     fn can_encode_and_decode_ssz() {
         let original: BeaconState<MainnetEthSpec> = BeaconState::new();
         let serialized: Vec<u8> = original.as_ssz_bytes();
-        let deserialized: BeaconState<MainnetEthSpec> = BeaconState::from_ssz_bytes(&serialized).unwrap();
+        let deserialized: BeaconState<MainnetEthSpec> =
+            BeaconState::from_ssz_bytes(&serialized).unwrap();
         assert_eq!(original, deserialized);
     }
 }

--- a/eth2/types/src/beacon_state.rs
+++ b/eth2/types/src/beacon_state.rs
@@ -1,4 +1,4 @@
-// Makes heavy use of patterns and code found in sigp/lighthouse
+// Makes use of patterns and code found in https://github.com/sigp/lighthouse
 use crate::cross_link::CrossLink;
 use crate::eth_spec::EthSpec;
 use crate::execution_environment::ExecutionEnvironment;

--- a/eth2/types/src/beacon_state.rs
+++ b/eth2/types/src/beacon_state.rs
@@ -2,7 +2,7 @@
 use crate::cross_link::CrossLink;
 use crate::eth_spec::EthSpec;
 use crate::execution_environment::ExecutionEnvironment;
-use crate::newtypes::{Root, Slot};
+use crate::slot_epoch_root::{Root, Slot};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use ssz::{Decode, Encode};

--- a/eth2/types/src/cross_link.rs
+++ b/eth2/types/src/cross_link.rs
@@ -1,4 +1,4 @@
-use crate::newtypes::{Root, Slot};
+use crate::slot_epoch_root::{Root, Slot};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;

--- a/eth2/types/src/cross_link.rs
+++ b/eth2/types/src/cross_link.rs
@@ -1,0 +1,20 @@
+use crate::newtypes::{Root, Slot};
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use ssz_types::{VariableList};
+// TODO: Replace this with the spec-defined max # of slots back each crosslink can hold
+use typenum::U64;
+
+#[derive(
+Debug,
+PartialEq,
+Clone,
+Default,
+Deserialize,
+Serialize,
+Encode,
+Decode,
+)]
+pub struct CrossLink {
+    shard_roots: VariableList<(Slot, Root), U64>
+}

--- a/eth2/types/src/cross_link.rs
+++ b/eth2/types/src/cross_link.rs
@@ -1,20 +1,11 @@
 use crate::newtypes::{Root, Slot};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{VariableList};
+use ssz_types::VariableList;
 // TODO: Replace this with the spec-defined max # of slots back each crosslink can hold
 use typenum::U64;
 
-#[derive(
-Debug,
-PartialEq,
-Clone,
-Default,
-Deserialize,
-Serialize,
-Encode,
-Decode,
-)]
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize, Encode, Decode)]
 pub struct CrossLink {
-    shard_roots: VariableList<(Slot, Root), U64>
+    shard_roots: VariableList<(Slot, Root), U64>,
 }

--- a/eth2/types/src/eth_spec.rs
+++ b/eth2/types/src/eth_spec.rs
@@ -1,0 +1,89 @@
+// Copied from sigp/lighthouse with some modifications and deletions
+use crate::beacon_state::BeaconState;
+use crate::newtypes::Epoch;
+use serde::{Deserialize, Serialize};
+use typenum::{
+    Unsigned, U0, U1, U1024, U1099511627776, U128, U16, U16777216, U2048, U32, U4, U4096, U64,
+    U65536, U8, U8192,
+};
+use std::fmt::Debug;
+
+pub trait EthSpec: 'static + Default + Sync + Send + Clone + Debug + PartialEq {
+    /*
+     * Unspecced values
+     */
+    type ShardCount: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type MaxExecutionEnvironments: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+
+    /*
+     * Constants
+     */
+    type JustificationBitsLength: Unsigned + Clone + Sync + Send + Debug + PartialEq + Default;
+    /*
+     * Misc
+     */
+    type MaxValidatorsPerCommittee: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    /*
+     * Initial values
+     */
+    type GenesisEpoch: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    /*
+     * Time parameters
+     */
+    type SlotsPerEpoch: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type SlotsPerEth1VotingPeriod: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type SlotsPerHistoricalRoot: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    /*
+     * State list lengths
+     */
+    type EpochsPerHistoricalVector: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type EpochsPerSlashingsVector: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type HistoricalRootsLimit: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type ValidatorRegistryLimit: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    /*
+     * Max operations per block
+     */
+    type MaxProposerSlashings: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type MaxAttesterSlashings: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type MaxAttestations: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type MaxDeposits: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type MaxVoluntaryExits: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    /*
+     * Derived values (set these CAREFULLY)
+     */
+    /// The length of the `{previous,current}_epoch_attestations` lists.
+    ///
+    /// Must be set to `MaxAttestations * SlotsPerEpoch`
+    // NOTE: we could safely instantiate this by using type-level arithmetic, but doing
+    // so adds ~25s to the time required to type-check this crate
+    type MaxPendingAttestations: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+}
+
+/// Ethereum Foundation specifications.
+///
+/// Spec v0.9.1
+#[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
+pub struct MainnetEthSpec;
+
+impl EthSpec for MainnetEthSpec {
+    type ShardCount = U64;
+    type MaxExecutionEnvironments = U65536;
+    type JustificationBitsLength = U4;
+    type MaxValidatorsPerCommittee = U2048;
+    type GenesisEpoch = U0;
+    type SlotsPerEpoch = U32;
+    type SlotsPerEth1VotingPeriod = U1024;
+    type SlotsPerHistoricalRoot = U8192;
+    type EpochsPerHistoricalVector = U65536;
+    type EpochsPerSlashingsVector = U8192;
+    type HistoricalRootsLimit = U16777216;
+    type ValidatorRegistryLimit = U1099511627776;
+    type MaxProposerSlashings = U16;
+    type MaxAttesterSlashings = U1;
+    type MaxAttestations = U128;
+    type MaxDeposits = U16;
+    type MaxVoluntaryExits = U16;
+    type MaxPendingAttestations = U4096; // 128 max attestations * 32 slots per epoch
+}
+
+pub type FoundationBeaconState = BeaconState<MainnetEthSpec>;

--- a/eth2/types/src/eth_spec.rs
+++ b/eth2/types/src/eth_spec.rs
@@ -2,11 +2,11 @@
 use crate::beacon_state::BeaconState;
 use crate::newtypes::Epoch;
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 use typenum::{
     Unsigned, U0, U1, U1024, U1099511627776, U128, U16, U16777216, U2048, U32, U4, U4096, U64,
     U65536, U8, U8192,
 };
-use std::fmt::Debug;
 
 pub trait EthSpec: 'static + Default + Sync + Send + Clone + Debug + PartialEq {
     /*

--- a/eth2/types/src/eth_spec.rs
+++ b/eth2/types/src/eth_spec.rs
@@ -2,7 +2,7 @@
 // with some modifications and deletions. Specifically, removed code that wasn't necessary for this
 // repository, updated to use explicit imports, and added additional values to the spec definition.
 use crate::beacon_state::BeaconState;
-use crate::newtypes::Epoch;
+use crate::slot_epoch_root::Epoch;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use typenum::{
@@ -17,48 +17,48 @@ pub trait EthSpec: 'static + Default + Sync + Send + Clone + Debug + PartialEq {
     type ShardCount: Unsigned + Clone + Sync + Send + Debug + PartialEq;
     type MaxExecutionEnvironments: Unsigned + Clone + Sync + Send + Debug + PartialEq;
 
-    /*
-     * Constants
-     */
-    type JustificationBitsLength: Unsigned + Clone + Sync + Send + Debug + PartialEq + Default;
-    /*
-     * Misc
-     */
-    type MaxValidatorsPerCommittee: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    /*
-     * Initial values
-     */
-    type GenesisEpoch: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    /*
-     * Time parameters
-     */
-    type SlotsPerEpoch: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    type SlotsPerEth1VotingPeriod: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    type SlotsPerHistoricalRoot: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    /*
-     * State list lengths
-     */
-    type EpochsPerHistoricalVector: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    type EpochsPerSlashingsVector: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    type HistoricalRootsLimit: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    type ValidatorRegistryLimit: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    /*
-     * Max operations per block
-     */
-    type MaxProposerSlashings: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    type MaxAttesterSlashings: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    type MaxAttestations: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    type MaxDeposits: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    type MaxVoluntaryExits: Unsigned + Clone + Sync + Send + Debug + PartialEq;
-    /*
-     * Derived values (set these CAREFULLY)
-     */
-    /// The length of the `{previous,current}_epoch_attestations` lists.
-    ///
-    /// Must be set to `MaxAttestations * SlotsPerEpoch`
-    // NOTE: we could safely instantiate this by using type-level arithmetic, but doing
-    // so adds ~25s to the time required to type-check this crate
-    type MaxPendingAttestations: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    /*
+//     * Constants
+//     */
+//    type JustificationBitsLength: Unsigned + Clone + Sync + Send + Debug + PartialEq + Default;
+//    /*
+//     * Misc
+//     */
+//    type MaxValidatorsPerCommittee: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    /*
+//     * Initial values
+//     */
+//    type GenesisEpoch: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    /*
+//     * Time parameters
+//     */
+//    type SlotsPerEpoch: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    type SlotsPerEth1VotingPeriod: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    type SlotsPerHistoricalRoot: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    /*
+//     * State list lengths
+//     */
+//    type EpochsPerHistoricalVector: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    type EpochsPerSlashingsVector: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    type HistoricalRootsLimit: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    type ValidatorRegistryLimit: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    /*
+//     * Max operations per block
+//     */
+//    type MaxProposerSlashings: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    type MaxAttesterSlashings: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    type MaxAttestations: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    type MaxDeposits: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    type MaxVoluntaryExits: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+//    /*
+//     * Derived values (set these CAREFULLY)
+//     */
+//    /// The length of the `{previous,current}_epoch_attestations` lists.
+//    ///
+//    /// Must be set to `MaxAttestations * SlotsPerEpoch`
+//    // NOTE: we could safely instantiate this by using type-level arithmetic, but doing
+//    // so adds ~25s to the time required to type-check this crate
+//    type MaxPendingAttestations: Unsigned + Clone + Sync + Send + Debug + PartialEq;
 }
 
 /// Ethereum Foundation specifications.
@@ -70,22 +70,22 @@ pub struct MainnetEthSpec;
 impl EthSpec for MainnetEthSpec {
     type ShardCount = U64;
     type MaxExecutionEnvironments = U65536;
-    type JustificationBitsLength = U4;
-    type MaxValidatorsPerCommittee = U2048;
-    type GenesisEpoch = U0;
-    type SlotsPerEpoch = U32;
-    type SlotsPerEth1VotingPeriod = U1024;
-    type SlotsPerHistoricalRoot = U8192;
-    type EpochsPerHistoricalVector = U65536;
-    type EpochsPerSlashingsVector = U8192;
-    type HistoricalRootsLimit = U16777216;
-    type ValidatorRegistryLimit = U1099511627776;
-    type MaxProposerSlashings = U16;
-    type MaxAttesterSlashings = U1;
-    type MaxAttestations = U128;
-    type MaxDeposits = U16;
-    type MaxVoluntaryExits = U16;
-    type MaxPendingAttestations = U4096; // 128 max attestations * 32 slots per epoch
+//    type JustificationBitsLength = U4;
+//    type MaxValidatorsPerCommittee = U2048;
+//    type GenesisEpoch = U0;
+//    type SlotsPerEpoch = U32;
+//    type SlotsPerEth1VotingPeriod = U1024;
+//    type SlotsPerHistoricalRoot = U8192;
+//    type EpochsPerHistoricalVector = U65536;
+//    type EpochsPerSlashingsVector = U8192;
+//    type HistoricalRootsLimit = U16777216;
+//    type ValidatorRegistryLimit = U1099511627776;
+//    type MaxProposerSlashings = U16;
+//    type MaxAttesterSlashings = U1;
+//    type MaxAttestations = U128;
+//    type MaxDeposits = U16;
+//    type MaxVoluntaryExits = U16;
+//    type MaxPendingAttestations = U4096; // 128 max attestations * 32 slots per epoch
 }
 
 pub type FoundationBeaconState = BeaconState<MainnetEthSpec>;

--- a/eth2/types/src/eth_spec.rs
+++ b/eth2/types/src/eth_spec.rs
@@ -1,4 +1,6 @@
-// Copied from sigp/lighthouse with some modifications and deletions
+// Copied from file of the same name at https://github.com/sigp/lighthouse
+// with some modifications and deletions. Specifically, removed code that wasn't necessary for this
+// repository, updated to use explicit imports, and added additional values to the spec definition.
 use crate::beacon_state::BeaconState;
 use crate::newtypes::Epoch;
 use serde::{Deserialize, Serialize};

--- a/eth2/types/src/execution_environment.rs
+++ b/eth2/types/src/execution_environment.rs
@@ -1,19 +1,11 @@
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{VariableList};
+use ssz_types::VariableList;
 // TODO: Replace this with the actual max # of bytes an EE can have
 // Currently this is arbitrarily set to 256KB max size
 use typenum::U262144;
 
-#[derive(
-Debug,
-PartialEq,
-Clone,
-Deserialize,
-Serialize,
-Encode,
-Decode,
-)]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Encode, Decode)]
 pub struct ExecutionEnvironment {
     wasm_code: VariableList<u8, U262144>,
 }

--- a/eth2/types/src/execution_environment.rs
+++ b/eth2/types/src/execution_environment.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use ssz_types::{VariableList};
+// TODO: Replace this with the actual max # of bytes an EE can have
+// Currently this is arbitrarily set to 256KB max size
+use typenum::U262144;
+
+#[derive(
+Debug,
+PartialEq,
+Clone,
+Deserialize,
+Serialize,
+Encode,
+Decode,
+)]
+pub struct ExecutionEnvironment {
+    wasm_code: VariableList<u8, U262144>,
+}

--- a/eth2/types/src/lib.rs
+++ b/eth2/types/src/lib.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+pub mod u64_macros;
+
+pub mod beacon_state;
+pub mod cross_link;
+pub mod eth_spec;
+pub mod execution_environment;
+pub mod newtypes;

--- a/eth2/types/src/lib.rs
+++ b/eth2/types/src/lib.rs
@@ -5,4 +5,4 @@ pub mod beacon_state;
 pub mod cross_link;
 pub mod eth_spec;
 pub mod execution_environment;
-pub mod newtypes;
+pub mod slot_epoch_root;

--- a/eth2/types/src/newtypes.rs
+++ b/eth2/types/src/newtypes.rs
@@ -1,14 +1,14 @@
 // Many patterns here copied from sigp/lighthouse with some small modifications
-use fixed_hash::{construct_fixed_hash};
+use fixed_hash::construct_fixed_hash;
 
 // Necessary for impl_common macro
 use serde::{Deserialize, Serialize};
 use slog;
+use ssz::{ssz_encode, Decode, DecodeError, Encode};
 use std::cmp::{Ord, Ordering};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, Sub, SubAssign};
-use ssz::{ssz_encode, Decode, DecodeError, Encode};
 
 #[derive(Eq, Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/eth2/types/src/newtypes.rs
+++ b/eth2/types/src/newtypes.rs
@@ -1,4 +1,9 @@
-// Many patterns here copied from sigp/lighthouse with some small modifications
+// Many patterns copied from the slot_epoch.rs file in the
+// https://github.com/sigp/lighthouse repo with some small modifications.  Specifically, added new
+// types, and removed code not needed for this repo.
+// The analog of the `Root` struct in this repo is H256 in lighthouse (and in some other
+// ethereum-focused crates). Decided to use `Root` in this repo instead of `H256` because the spec
+// refers to the data type as a `Root`.  This can be changed in the future if necessary.
 use fixed_hash::construct_fixed_hash;
 
 // Necessary for impl_common macro

--- a/eth2/types/src/newtypes.rs
+++ b/eth2/types/src/newtypes.rs
@@ -1,0 +1,83 @@
+// Many patterns here copied from sigp/lighthouse with some small modifications
+use fixed_hash::{construct_fixed_hash};
+
+// Necessary for impl_common macro
+use serde::{Deserialize, Serialize};
+use slog;
+use std::cmp::{Ord, Ordering};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, Sub, SubAssign};
+use ssz::{ssz_encode, Decode, DecodeError, Encode};
+
+#[derive(Eq, Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Slot(u64);
+
+#[derive(Eq, Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct Epoch(u64);
+
+#[derive(Eq, Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Shard(u64);
+
+#[derive(Eq, Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ShardSlot(u64);
+
+impl_common!(Slot);
+impl_common!(Epoch);
+impl_common!(Shard);
+impl_common!(ShardSlot);
+
+construct_fixed_hash! {
+    #[derive(Serialize, Deserialize)]
+    pub struct Root(32);
+}
+
+impl Slot {
+    pub fn new(slot: u64) -> Self {
+        Self(slot)
+    }
+}
+
+impl Epoch {
+    pub fn new(slot: u64) -> Self {
+        Self(slot)
+    }
+}
+
+impl Decode for Root {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        32
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        let len = bytes.len();
+        let expected = <Self as Decode>::ssz_fixed_len();
+
+        if len != expected {
+            Err(DecodeError::InvalidByteLength { len, expected })
+        } else {
+            Ok(Root::from_slice(bytes))
+        }
+    }
+}
+
+impl Encode for Root {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        32
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(self.as_bytes());
+    }
+}

--- a/eth2/types/src/slot_epoch_root.rs
+++ b/eth2/types/src/slot_epoch_root.rs
@@ -8,7 +8,6 @@ use fixed_hash::construct_fixed_hash;
 
 // Necessary for impl_common macro
 use serde::{Deserialize, Serialize};
-use slog;
 use ssz::{ssz_encode, Decode, DecodeError, Encode};
 use std::cmp::{Ord, Ordering};
 use std::fmt;

--- a/eth2/types/src/u64_macros.rs
+++ b/eth2/types/src/u64_macros.rs
@@ -1,4 +1,6 @@
-// Copied from sigp/lighthouse with some small modifications
+// Copied from the slot_epoch_macros.rs file in https://github.com/sigp/lighthouse with some small
+// modifications.  Specifically, updated ssz macro to match the eth2_ssz crate's Encode trait, which
+// is slightly different than the Encode trait used internally in the sigp/lighthouse repo.
 
 macro_rules! impl_from_into_u64 {
     ($main: ident) => {

--- a/eth2/types/src/u64_macros.rs
+++ b/eth2/types/src/u64_macros.rs
@@ -205,9 +205,9 @@ macro_rules! impl_ssz {
 
             // Commented after copying from sigp/lighthouse
             // Not a member of the eth2_ssz library's trait `Encode`
-//            fn ssz_bytes_len(&self) -> usize {
-//                0_u64.ssz_bytes_len()
-//            }
+            //            fn ssz_bytes_len(&self) -> usize {
+            //                0_u64.ssz_bytes_len()
+            //            }
 
             fn ssz_append(&self, buf: &mut Vec<u8>) {
                 self.0.ssz_append(buf)
@@ -246,11 +246,11 @@ macro_rules! impl_ssz {
             }
         }
 
-//        impl TestRandom for $type {
-//            fn random_for_test(rng: &mut impl RngCore) -> Self {
-//                $type::from(u64::random_for_test(rng))
-//            }
-//        }
+        //        impl TestRandom for $type {
+        //            fn random_for_test(rng: &mut impl RngCore) -> Self {
+        //                $type::from(u64::random_for_test(rng))
+        //            }
+        //        }
     };
 }
 

--- a/eth2/types/src/u64_macros.rs
+++ b/eth2/types/src/u64_macros.rs
@@ -1,0 +1,608 @@
+// Copied from sigp/lighthouse with some small modifications
+
+macro_rules! impl_from_into_u64 {
+    ($main: ident) => {
+        impl From<u64> for $main {
+            fn from(n: u64) -> $main {
+                $main(n)
+            }
+        }
+
+        impl Into<u64> for $main {
+            fn into(self) -> u64 {
+                self.0
+            }
+        }
+
+        impl $main {
+            pub fn as_u64(&self) -> u64 {
+                self.0
+            }
+        }
+    };
+}
+
+macro_rules! impl_from_into_usize {
+    ($main: ident) => {
+        impl From<usize> for $main {
+            fn from(n: usize) -> $main {
+                $main(n as u64)
+            }
+        }
+
+        impl Into<usize> for $main {
+            fn into(self) -> usize {
+                self.0 as usize
+            }
+        }
+
+        impl $main {
+            pub fn as_usize(&self) -> usize {
+                self.0 as usize
+            }
+        }
+    };
+}
+
+macro_rules! impl_math_between {
+    ($main: ident, $other: ident) => {
+        impl PartialOrd<$other> for $main {
+            /// Utilizes `partial_cmp` on the underlying `u64`.
+            fn partial_cmp(&self, other: &$other) -> Option<Ordering> {
+                Some(self.0.cmp(&(*other).into()))
+            }
+        }
+
+        impl PartialEq<$other> for $main {
+            fn eq(&self, other: &$other) -> bool {
+                let other: u64 = (*other).into();
+                self.0 == other
+            }
+        }
+
+        impl Add<$other> for $main {
+            type Output = $main;
+
+            fn add(self, other: $other) -> $main {
+                $main::from(self.0.saturating_add(other.into()))
+            }
+        }
+
+        impl AddAssign<$other> for $main {
+            fn add_assign(&mut self, other: $other) {
+                self.0 = self.0.saturating_add(other.into());
+            }
+        }
+
+        impl Sub<$other> for $main {
+            type Output = $main;
+
+            fn sub(self, other: $other) -> $main {
+                $main::from(self.0.saturating_sub(other.into()))
+            }
+        }
+
+        impl SubAssign<$other> for $main {
+            fn sub_assign(&mut self, other: $other) {
+                self.0 = self.0.saturating_sub(other.into());
+            }
+        }
+
+        impl Mul<$other> for $main {
+            type Output = $main;
+
+            fn mul(self, rhs: $other) -> $main {
+                let rhs: u64 = rhs.into();
+                $main::from(self.0.saturating_mul(rhs))
+            }
+        }
+
+        impl MulAssign<$other> for $main {
+            fn mul_assign(&mut self, rhs: $other) {
+                let rhs: u64 = rhs.into();
+                self.0 = self.0.saturating_mul(rhs)
+            }
+        }
+
+        impl Div<$other> for $main {
+            type Output = $main;
+
+            fn div(self, rhs: $other) -> $main {
+                let rhs: u64 = rhs.into();
+                if rhs == 0 {
+                    panic!("Cannot divide by zero-valued Slot/Epoch")
+                }
+                $main::from(self.0 / rhs)
+            }
+        }
+
+        impl DivAssign<$other> for $main {
+            fn div_assign(&mut self, rhs: $other) {
+                let rhs: u64 = rhs.into();
+                if rhs == 0 {
+                    panic!("Cannot divide by zero-valued Slot/Epoch")
+                }
+                self.0 = self.0 / rhs
+            }
+        }
+
+        impl Rem<$other> for $main {
+            type Output = $main;
+
+            fn rem(self, modulus: $other) -> $main {
+                let modulus: u64 = modulus.into();
+                $main::from(self.0 % modulus)
+            }
+        }
+    };
+}
+
+macro_rules! impl_math {
+    ($type: ident) => {
+        impl $type {
+            pub fn saturating_sub<T: Into<$type>>(&self, other: T) -> $type {
+                *self - other.into()
+            }
+
+            pub fn saturating_add<T: Into<$type>>(&self, other: T) -> $type {
+                *self + other.into()
+            }
+
+            pub fn checked_div<T: Into<$type>>(&self, rhs: T) -> Option<$type> {
+                let rhs: $type = rhs.into();
+                if rhs == 0 {
+                    None
+                } else {
+                    Some(*self / rhs)
+                }
+            }
+
+            pub fn is_power_of_two(&self) -> bool {
+                self.0.is_power_of_two()
+            }
+        }
+
+        impl Ord for $type {
+            fn cmp(&self, other: &$type) -> Ordering {
+                let other: u64 = (*other).into();
+                self.0.cmp(&other)
+            }
+        }
+    };
+}
+
+macro_rules! impl_display {
+    ($type: ident) => {
+        impl fmt::Display for $type {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl slog::Value for $type {
+            fn serialize(
+                &self,
+                record: &slog::Record,
+                key: slog::Key,
+                serializer: &mut dyn slog::Serializer,
+            ) -> slog::Result {
+                slog::Value::serialize(&self.0, record, key, serializer)
+            }
+        }
+    };
+}
+
+macro_rules! impl_ssz {
+    ($type: ident) => {
+        impl Encode for $type {
+            fn is_ssz_fixed_len() -> bool {
+                <u64 as Encode>::is_ssz_fixed_len()
+            }
+
+            fn ssz_fixed_len() -> usize {
+                <u64 as Encode>::ssz_fixed_len()
+            }
+
+            // Commented after copying from sigp/lighthouse
+            // Not a member of the eth2_ssz library's trait `Encode`
+//            fn ssz_bytes_len(&self) -> usize {
+//                0_u64.ssz_bytes_len()
+//            }
+
+            fn ssz_append(&self, buf: &mut Vec<u8>) {
+                self.0.ssz_append(buf)
+            }
+        }
+
+        impl Decode for $type {
+            fn is_ssz_fixed_len() -> bool {
+                <u64 as Decode>::is_ssz_fixed_len()
+            }
+
+            fn ssz_fixed_len() -> usize {
+                <u64 as Decode>::ssz_fixed_len()
+            }
+
+            fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+                Ok($type(u64::from_ssz_bytes(bytes)?))
+            }
+        }
+
+        impl tree_hash::TreeHash for $type {
+            fn tree_hash_type() -> tree_hash::TreeHashType {
+                tree_hash::TreeHashType::Basic
+            }
+
+            fn tree_hash_packed_encoding(&self) -> Vec<u8> {
+                ssz_encode(self)
+            }
+
+            fn tree_hash_packing_factor() -> usize {
+                32 / 8
+            }
+
+            fn tree_hash_root(&self) -> Vec<u8> {
+                int_to_bytes::int_to_bytes32(self.0)
+            }
+        }
+
+//        impl TestRandom for $type {
+//            fn random_for_test(rng: &mut impl RngCore) -> Self {
+//                $type::from(u64::random_for_test(rng))
+//            }
+//        }
+    };
+}
+
+macro_rules! impl_hash {
+    ($type: ident) => {
+        // Implemented to stop clippy lint:
+        // https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq
+        impl Hash for $type {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                ssz_encode(self).hash(state)
+            }
+        }
+    };
+}
+
+macro_rules! impl_common {
+    ($type: ident) => {
+        impl_from_into_u64!($type);
+        impl_from_into_usize!($type);
+        impl_math_between!($type, $type);
+        impl_math_between!($type, u64);
+        impl_math!($type);
+        impl_display!($type);
+        impl_ssz!($type);
+        impl_hash!($type);
+    };
+}
+
+// test macros
+#[cfg(test)]
+macro_rules! new_tests {
+    ($type: ident) => {
+        #[test]
+        fn new() {
+            assert_eq!($type(0), $type::new(0));
+            assert_eq!($type(3), $type::new(3));
+            assert_eq!($type(u64::max_value()), $type::new(u64::max_value()));
+        }
+    };
+}
+
+#[cfg(test)]
+macro_rules! from_into_tests {
+    ($type: ident, $other: ident) => {
+        #[test]
+        fn into() {
+            let x: $other = $type(0).into();
+            assert_eq!(x, 0);
+
+            let x: $other = $type(3).into();
+            assert_eq!(x, 3);
+
+            let x: $other = $type(u64::max_value()).into();
+            // Note: this will fail on 32 bit systems. This is expected as we don't have a proper
+            // 32-bit system strategy in place.
+            assert_eq!(x, $other::max_value());
+        }
+
+        #[test]
+        fn from() {
+            assert_eq!($type(0), $type::from(0_u64));
+            assert_eq!($type(3), $type::from(3_u64));
+            assert_eq!($type(u64::max_value()), $type::from($other::max_value()));
+        }
+    };
+}
+
+#[cfg(test)]
+macro_rules! math_between_tests {
+    ($type: ident, $other: ident) => {
+        #[test]
+        fn partial_ord() {
+            let assert_partial_ord = |a: u64, partial_ord: Ordering, b: u64| {
+                let other: $other = $type(b).into();
+                assert_eq!($type(a).partial_cmp(&other), Some(partial_ord));
+            };
+
+            assert_partial_ord(1, Ordering::Less, 2);
+            assert_partial_ord(2, Ordering::Greater, 1);
+            assert_partial_ord(0, Ordering::Less, u64::max_value());
+            assert_partial_ord(u64::max_value(), Ordering::Greater, 0);
+        }
+
+        #[test]
+        fn partial_eq() {
+            let assert_partial_eq = |a: u64, b: u64, is_equal: bool| {
+                let other: $other = $type(b).into();
+                assert_eq!($type(a).eq(&other), is_equal);
+            };
+
+            assert_partial_eq(0, 0, true);
+            assert_partial_eq(0, 1, false);
+            assert_partial_eq(1, 0, false);
+            assert_partial_eq(1, 1, true);
+
+            assert_partial_eq(u64::max_value(), u64::max_value(), true);
+            assert_partial_eq(0, u64::max_value(), false);
+            assert_partial_eq(u64::max_value(), 0, false);
+        }
+
+        #[test]
+        fn add_and_add_assign() {
+            let assert_add = |a: u64, b: u64, result: u64| {
+                let other: $other = $type(b).into();
+                assert_eq!($type(a) + other, $type(result));
+
+                let mut add_assigned = $type(a);
+                add_assigned += other;
+
+                assert_eq!(add_assigned, $type(result));
+            };
+
+            assert_add(0, 1, 1);
+            assert_add(1, 0, 1);
+            assert_add(1, 2, 3);
+            assert_add(2, 1, 3);
+            assert_add(7, 7, 14);
+
+            // Addition should be saturating.
+            assert_add(u64::max_value(), 1, u64::max_value());
+            assert_add(u64::max_value(), u64::max_value(), u64::max_value());
+        }
+
+        #[test]
+        fn sub_and_sub_assign() {
+            let assert_sub = |a: u64, b: u64, result: u64| {
+                let other: $other = $type(b).into();
+                assert_eq!($type(a) - other, $type(result));
+
+                let mut sub_assigned = $type(a);
+                sub_assigned -= other;
+
+                assert_eq!(sub_assigned, $type(result));
+            };
+
+            assert_sub(1, 0, 1);
+            assert_sub(2, 1, 1);
+            assert_sub(14, 7, 7);
+            assert_sub(u64::max_value(), 1, u64::max_value() - 1);
+            assert_sub(u64::max_value(), u64::max_value(), 0);
+
+            // Subtraction should be saturating
+            assert_sub(0, 1, 0);
+            assert_sub(1, 2, 0);
+        }
+
+        #[test]
+        fn mul_and_mul_assign() {
+            let assert_mul = |a: u64, b: u64, result: u64| {
+                let other: $other = $type(b).into();
+                assert_eq!($type(a) * other, $type(result));
+
+                let mut mul_assigned = $type(a);
+                mul_assigned *= other;
+
+                assert_eq!(mul_assigned, $type(result));
+            };
+
+            assert_mul(2, 2, 4);
+            assert_mul(1, 2, 2);
+            assert_mul(0, 2, 0);
+
+            // Multiplication should be saturating.
+            assert_mul(u64::max_value(), 2, u64::max_value());
+        }
+
+        #[test]
+        fn div_and_div_assign() {
+            let assert_div = |a: u64, b: u64, result: u64| {
+                let other: $other = $type(b).into();
+                assert_eq!($type(a) / other, $type(result));
+
+                let mut div_assigned = $type(a);
+                div_assigned /= other;
+
+                assert_eq!(div_assigned, $type(result));
+            };
+
+            assert_div(0, 2, 0);
+            assert_div(2, 2, 1);
+            assert_div(100, 50, 2);
+            assert_div(128, 2, 64);
+            assert_div(u64::max_value(), 2, 2_u64.pow(63) - 1);
+        }
+
+        #[test]
+        #[should_panic]
+        fn div_panics_with_divide_by_zero() {
+            let other: $other = $type(0).into();
+            let _ = $type(2) / other;
+        }
+
+        #[test]
+        #[should_panic]
+        fn div_assign_panics_with_divide_by_zero() {
+            let other: $other = $type(0).into();
+            let mut assigned = $type(2);
+            assigned /= other;
+        }
+
+        #[test]
+        fn rem() {
+            let assert_rem = |a: u64, b: u64, result: u64| {
+                let other: $other = $type(b).into();
+                assert_eq!($type(a) % other, $type(result));
+            };
+
+            assert_rem(3, 2, 1);
+            assert_rem(40, 2, 0);
+            assert_rem(10, 100, 10);
+            assert_rem(302042, 3293, 2379);
+        }
+    };
+}
+
+#[cfg(test)]
+macro_rules! math_tests {
+    ($type: ident) => {
+        #[test]
+        fn saturating_sub() {
+            let assert_saturating_sub = |a: u64, b: u64, result: u64| {
+                assert_eq!($type(a).saturating_sub($type(b)), $type(result));
+            };
+
+            assert_saturating_sub(1, 0, 1);
+            assert_saturating_sub(2, 1, 1);
+            assert_saturating_sub(14, 7, 7);
+            assert_saturating_sub(u64::max_value(), 1, u64::max_value() - 1);
+            assert_saturating_sub(u64::max_value(), u64::max_value(), 0);
+
+            // Subtraction should be saturating
+            assert_saturating_sub(0, 1, 0);
+            assert_saturating_sub(1, 2, 0);
+        }
+
+        #[test]
+        fn saturating_add() {
+            let assert_saturating_add = |a: u64, b: u64, result: u64| {
+                assert_eq!($type(a).saturating_add($type(b)), $type(result));
+            };
+
+            assert_saturating_add(0, 1, 1);
+            assert_saturating_add(1, 0, 1);
+            assert_saturating_add(1, 2, 3);
+            assert_saturating_add(2, 1, 3);
+            assert_saturating_add(7, 7, 14);
+
+            // Addition should be saturating.
+            assert_saturating_add(u64::max_value(), 1, u64::max_value());
+            assert_saturating_add(u64::max_value(), u64::max_value(), u64::max_value());
+        }
+
+        #[test]
+        fn checked_div() {
+            let assert_checked_div = |a: u64, b: u64, result: Option<u64>| {
+                let division_result_as_u64 = match $type(a).checked_div($type(b)) {
+                    None => None,
+                    Some(val) => Some(val.as_u64()),
+                };
+                assert_eq!(division_result_as_u64, result);
+            };
+
+            assert_checked_div(0, 2, Some(0));
+            assert_checked_div(2, 2, Some(1));
+            assert_checked_div(100, 50, Some(2));
+            assert_checked_div(128, 2, Some(64));
+            assert_checked_div(u64::max_value(), 2, Some(2_u64.pow(63) - 1));
+
+            assert_checked_div(2, 0, None);
+            assert_checked_div(0, 0, None);
+            assert_checked_div(u64::max_value(), 0, None);
+        }
+
+        #[test]
+        fn is_power_of_two() {
+            let assert_is_power_of_two = |a: u64, result: bool| {
+                assert_eq!(
+                    $type(a).is_power_of_two(),
+                    result,
+                    "{}.is_power_of_two() != {}",
+                    a,
+                    result
+                );
+            };
+
+            assert_is_power_of_two(0, false);
+            assert_is_power_of_two(1, true);
+            assert_is_power_of_two(2, true);
+            assert_is_power_of_two(3, false);
+            assert_is_power_of_two(4, true);
+
+            assert_is_power_of_two(2_u64.pow(4), true);
+            assert_is_power_of_two(u64::max_value(), false);
+        }
+
+        #[test]
+        fn ord() {
+            let assert_ord = |a: u64, ord: Ordering, b: u64| {
+                assert_eq!($type(a).cmp(&$type(b)), ord);
+            };
+
+            assert_ord(1, Ordering::Less, 2);
+            assert_ord(2, Ordering::Greater, 1);
+            assert_ord(0, Ordering::Less, u64::max_value());
+            assert_ord(u64::max_value(), Ordering::Greater, 0);
+        }
+    };
+}
+
+#[cfg(test)]
+macro_rules! all_tests {
+    ($type: ident) => {
+        new_tests!($type);
+        math_between_tests!($type, $type);
+        math_tests!($type);
+        ssz_tests!($type);
+
+        mod u64_tests {
+            use super::*;
+
+            from_into_tests!($type, u64);
+            math_between_tests!($type, u64);
+
+            #[test]
+            pub fn as_64() {
+                let x = $type(0).as_u64();
+                assert_eq!(x, 0);
+
+                let x = $type(3).as_u64();
+                assert_eq!(x, 3);
+
+                let x = $type(u64::max_value()).as_u64();
+                assert_eq!(x, u64::max_value());
+            }
+        }
+
+        mod usize_tests {
+            use super::*;
+
+            from_into_tests!($type, usize);
+
+            #[test]
+            pub fn as_usize() {
+                let x = $type(0).as_usize();
+                assert_eq!(x, 0);
+
+                let x = $type(3).as_usize();
+                assert_eq!(x, 3);
+
+                let x = $type(u64::max_value()).as_usize();
+                assert_eq!(x, usize::max_value());
+            }
+        }
+    };
+}

--- a/eth2/utils/int_to_bytes/Cargo.toml
+++ b/eth2/utils/int_to_bytes/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "int_to_bytes"
 version = "0.1.0"
-# Not really -- this package was copied from sigp/lighthouse (with some very slight
-# modifications and deletions to make it compatible with the code in this repository),
-# TODO: If there's a better way to give credit here, update this.
+# Not really -- this package was copied from https://github.com/sigp/lighthouse (with some slight
+# modifications and deletions, detailed at the top of the lib.rs file)
 authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
 edition = "2018"
 

--- a/eth2/utils/int_to_bytes/Cargo.toml
+++ b/eth2/utils/int_to_bytes/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "int_to_bytes"
+version = "0.1.0"
+# Not really -- this package was copied from sigp/lighthouse (with some very slight
+# modifications and deletions to make it compatible with the code in this repository),
+# TODO: If there's a better way to give credit here, update this.
+authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+bytes = "0.4.12"
+
+[dev-dependencies]
+yaml-rust = "0.4.3"
+hex = "0.3"

--- a/eth2/utils/int_to_bytes/Cargo.toml
+++ b/eth2/utils/int_to_bytes/Cargo.toml
@@ -3,6 +3,7 @@ name = "int_to_bytes"
 version = "0.1.0"
 # Not really -- this package was copied from https://github.com/sigp/lighthouse (with some slight
 # modifications and deletions, detailed at the top of the lib.rs file)
+# (sigp/lighthouse license: https://github.com/sigp/lighthouse/blob/master/LICENSE)
 authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
 edition = "2018"
 

--- a/eth2/utils/int_to_bytes/src/lib.rs
+++ b/eth2/utils/int_to_bytes/src/lib.rs
@@ -1,0 +1,10 @@
+// Copied from sigp/lighthouse with some modifications and deletions
+use bytes::{BufMut, BytesMut};
+
+/// Returns `int` as little-endian bytes with a length of 32.
+pub fn int_to_bytes32(int: u64) -> Vec<u8> {
+    let mut bytes = BytesMut::with_capacity(32);
+    bytes.put_u64_le(int);
+    bytes.resize(32, 0);
+    bytes.to_vec()
+}

--- a/eth2/utils/int_to_bytes/src/lib.rs
+++ b/eth2/utils/int_to_bytes/src/lib.rs
@@ -1,4 +1,5 @@
-// Copied from sigp/lighthouse with some modifications and deletions
+// Copied from the file of the same name in the https://github.com/sigp/lighthouse repo with some
+// modifications and deletions.  Specifically, removed all code not needed for this repo.
 use bytes::{BufMut, BytesMut};
 
 /// Returns `int` as little-endian bytes with a length of 32.

--- a/eth2/utils/serde_hex/Cargo.toml
+++ b/eth2/utils/serde_hex/Cargo.toml
@@ -3,7 +3,7 @@ name = "serde_hex"
 version = "0.1.0"
 # Not really -- this package was copied from https://github.com/sigp/lighthouse (with some slight
 # modifications and deletions, detailed at the top of the lib.rs file)
-# TODO: If there's a better way to give credit here, update this.
+# (sigp/lighthouse license: https://github.com/sigp/lighthouse/blob/master/LICENSE)
 authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
 edition = "2018"
 

--- a/eth2/utils/serde_hex/Cargo.toml
+++ b/eth2/utils/serde_hex/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "serde_hex"
 version = "0.1.0"
-# Not really -- this package was copied from sigp/lighthouse (with some very slight
-# modifications and deletions to make it compatible with the code in this repository),
+# Not really -- this package was copied from https://github.com/sigp/lighthouse (with some slight
+# modifications and deletions, detailed at the top of the lib.rs file)
 # TODO: If there's a better way to give credit here, update this.
 authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
 edition = "2018"

--- a/eth2/utils/serde_hex/Cargo.toml
+++ b/eth2/utils/serde_hex/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "serde_hex"
+version = "0.1.0"
+# Not really -- this package was copied from sigp/lighthouse (with some very slight
+# modifications and deletions to make it compatible with the code in this repository),
+# TODO: If there's a better way to give credit here, update this.
+authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+serde = "1.0.102"
+hex = "0.3"

--- a/eth2/utils/serde_hex/src/lib.rs
+++ b/eth2/utils/serde_hex/src/lib.rs
@@ -1,0 +1,79 @@
+// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+
+use hex;
+use hex::ToHex;
+use serde::de::{self, Visitor};
+use std::fmt;
+
+pub fn encode<T: AsRef<[u8]>>(data: T) -> String {
+    let mut hex = String::with_capacity(data.as_ref().len() * 2);
+
+    // Writing to a string never errors, so we can unwrap here.
+    data.write_hex(&mut hex).unwrap();
+
+    let mut s = "0x".to_string();
+
+    s.push_str(hex.as_str());
+
+    s
+}
+
+pub struct PrefixedHexVisitor;
+
+impl<'de> Visitor<'de> for PrefixedHexVisitor {
+    type Value = Vec<u8>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a hex string with 0x prefix")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+    {
+        if value.starts_with("0x") {
+            Ok(hex::decode(&value[2..])
+                .map_err(|e| de::Error::custom(format!("invalid hex ({:?})", e)))?)
+        } else {
+            Err(de::Error::custom("missing 0x prefix"))
+        }
+    }
+}
+
+pub struct HexVisitor;
+
+impl<'de> Visitor<'de> for HexVisitor {
+    type Value = Vec<u8>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a hex string (irrelevant of prefix)")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+    {
+        Ok(hex::decode(value.trim_start_matches("0x"))
+            .map_err(|e| de::Error::custom(format!("invalid hex ({:?})", e)))?)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn encoding() {
+        let bytes = vec![0, 255];
+        let hex = encode(&bytes);
+        assert_eq!(hex.as_str(), "0x00ff");
+
+        let bytes = vec![];
+        let hex = encode(&bytes);
+        assert_eq!(hex.as_str(), "0x");
+
+        let bytes = vec![1, 2, 3];
+        let hex = encode(&bytes);
+        assert_eq!(hex.as_str(), "0x010203");
+    }
+}

--- a/eth2/utils/serde_hex/src/lib.rs
+++ b/eth2/utils/serde_hex/src/lib.rs
@@ -1,4 +1,5 @@
-// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+// Copied from the file of the same name in the https://github.com/sigp/lighthouse repo with some
+// modifications and deletions.  Specifically, removed all code not needed for this repo.
 
 use hex;
 use hex::ToHex;

--- a/eth2/utils/serde_hex/src/lib.rs
+++ b/eth2/utils/serde_hex/src/lib.rs
@@ -28,8 +28,8 @@ impl<'de> Visitor<'de> for PrefixedHexVisitor {
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where
-            E: de::Error,
+    where
+        E: de::Error,
     {
         if value.starts_with("0x") {
             Ok(hex::decode(&value[2..])
@@ -50,8 +50,8 @@ impl<'de> Visitor<'de> for HexVisitor {
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where
-            E: de::Error,
+    where
+        E: de::Error,
     {
         Ok(hex::decode(value.trim_start_matches("0x"))
             .map_err(|e| de::Error::custom(format!("invalid hex ({:?})", e)))?)

--- a/eth2/utils/ssz_types/Cargo.toml
+++ b/eth2/utils/ssz_types/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ssz_types"
 version = "0.1.0"
-# Not really -- this package was copied from sigp/lighthouse (with some very slight
-# modifications and deletions to make it compatible with the code in this repository),
+# Not really -- this package was copied from https://github.com/sigp/lighthouse (with some slight
+# modifications and deletions, detailed at the top of each .rs file)
 # TODO: If there's a better way to give credit here, update this.
 authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
 edition = "2018"

--- a/eth2/utils/ssz_types/Cargo.toml
+++ b/eth2/utils/ssz_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "ssz_types"
 version = "0.1.0"
 # Not really -- this package was copied from https://github.com/sigp/lighthouse (with some slight
 # modifications and deletions, detailed at the top of each .rs file)
-# TODO: If there's a better way to give credit here, update this.
+# (sigp/lighthouse license: https://github.com/sigp/lighthouse/blob/master/LICENSE)
 authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
 edition = "2018"
 

--- a/eth2/utils/ssz_types/Cargo.toml
+++ b/eth2/utils/ssz_types/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ssz_types"
+version = "0.1.0"
+# Not really -- this package was copied from sigp/lighthouse (with some very slight
+# modifications and deletions to make it compatible with the code in this repository),
+# TODO: If there's a better way to give credit here, update this.
+authors = ["Greg Trowbridge <gjtrowbridge@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+tree_hash = "0.1.0"
+serde = "1.0.102"
+serde_derive = "1.0.102"
+serde_hex = { path = "../serde_hex" }
+eth2_ssz = "0.1.2"
+typenum = "1.11.2"
+
+[dev-dependencies]
+serde_yaml = "0.8.11"
+tree_hash_derive = "0.1"

--- a/eth2/utils/ssz_types/src/bitfield.rs
+++ b/eth2/utils/ssz_types/src/bitfield.rs
@@ -1,0 +1,1198 @@
+// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+use crate::tree_hash::bitfield_bytes_tree_hash_root;
+use crate::Error;
+use core::marker::PhantomData;
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+use serde_hex::{encode as hex_encode, PrefixedHexVisitor};
+use ssz::{Decode, Encode};
+use typenum::Unsigned;
+
+/// A marker trait applied to `Variable` and `Fixed` that defines the behaviour of a `Bitfield`.
+pub trait BitfieldBehaviour: Clone {}
+
+/// A marker struct used to declare SSZ `Variable` behaviour on a `Bitfield`.
+///
+/// See the [`Bitfield`](struct.Bitfield.html) docs for usage.
+#[derive(Clone, PartialEq, Debug)]
+pub struct Variable<N> {
+    _phantom: PhantomData<N>,
+}
+
+/// A marker struct used to declare SSZ `Fixed` behaviour on a `Bitfield`.
+///
+/// See the [`Bitfield`](struct.Bitfield.html) docs for usage.
+#[derive(Clone, PartialEq, Debug)]
+pub struct Fixed<N> {
+    _phantom: PhantomData<N>,
+}
+
+impl<N: Unsigned + Clone> BitfieldBehaviour for Variable<N> {}
+impl<N: Unsigned + Clone> BitfieldBehaviour for Fixed<N> {}
+
+/// A heap-allocated, ordered, variable-length collection of `bool` values, limited to `N` bits.
+pub type BitList<N> = Bitfield<Variable<N>>;
+
+/// A heap-allocated, ordered, fixed-length collection of `bool` values, with `N` bits.
+///
+/// See [Bitfield](struct.Bitfield.html) documentation.
+pub type BitVector<N> = Bitfield<Fixed<N>>;
+
+/// A heap-allocated, ordered, fixed-length, collection of `bool` values. Use of
+/// [`BitList`](type.BitList.html) or [`BitVector`](type.BitVector.html) type aliases is preferred
+/// over direct use of this struct.
+///
+/// The `T` type parameter is used to define length behaviour with the `Variable` or `Fixed` marker
+/// structs.
+///
+/// The length of the Bitfield is set at instantiation (i.e., runtime, not compile time). However,
+/// use with a `Variable` sets a type-level (i.e., compile-time) maximum length and `Fixed`
+/// provides a type-level fixed length.
+///
+/// ## Example
+///
+/// The example uses the following crate-level type aliases:
+///
+/// - `BitList<N>` is an alias for `Bitfield<Variable<N>>`
+/// - `BitVector<N>` is an alias for `Bitfield<Fixed<N>>`
+///
+/// ```
+/// use ssz_types::{BitVector, BitList, typenum};
+///
+/// // `BitList` has a type-level maximum length. The length of the list is specified at runtime
+/// // and it must be less than or equal to `N`. After instantiation, `BitList` cannot grow or
+/// // shrink.
+/// type BitList8 = BitList<typenum::U8>;
+///
+/// // Creating a `BitList` with a larger-than-`N` capacity returns `None`.
+/// assert!(BitList8::with_capacity(9).is_err());
+///
+/// let mut bitlist = BitList8::with_capacity(4).unwrap();  // `BitList` permits a capacity of less than the maximum.
+/// assert!(bitlist.set(3, true).is_ok());  // Setting inside the instantiation capacity is permitted.
+/// assert!(bitlist.set(5, true).is_err());  // Setting outside that capacity is not.
+///
+/// // `BitVector` has a type-level fixed length. Unlike `BitList`, it cannot be instantiated with a custom length
+/// // or grow/shrink.
+/// type BitVector8 = BitVector<typenum::U8>;
+///
+/// let mut bitvector = BitVector8::new();
+/// assert_eq!(bitvector.len(), 8); // `BitVector` length is fixed at the type-level.
+/// assert!(bitvector.set(7, true).is_ok());  // Setting inside the capacity is permitted.
+/// assert!(bitvector.set(9, true).is_err());  // Setting outside the capacity is not.
+///
+/// ```
+///
+/// ## Note
+///
+/// The internal representation of the bitfield is the same as that required by SSZ. The lowest
+/// byte (by `Vec` index) stores the lowest bit-indices and the right-most bit stores the lowest
+/// bit-index. E.g., `vec![0b0000_0001, 0b0000_0010]` has bits `0, 9` set.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Bitfield<T> {
+    bytes: Vec<u8>,
+    len: usize,
+    _phantom: PhantomData<T>,
+}
+
+impl<N: Unsigned + Clone> Bitfield<Variable<N>> {
+    /// Instantiate with capacity for `num_bits` boolean values. The length cannot be grown or
+    /// shrunk after instantiation.
+    ///
+    /// All bits are initialized to `false`.
+    ///
+    /// Returns `None` if `num_bits > N`.
+    pub fn with_capacity(num_bits: usize) -> Result<Self, Error> {
+        if num_bits <= N::to_usize() {
+            Ok(Self {
+                bytes: vec![0; bytes_for_bit_len(num_bits)],
+                len: num_bits,
+                _phantom: PhantomData,
+            })
+        } else {
+            Err(Error::OutOfBounds {
+                i: Self::max_len(),
+                len: Self::max_len(),
+            })
+        }
+    }
+
+    /// Equal to `N` regardless of the value supplied to `with_capacity`.
+    pub fn max_len() -> usize {
+        N::to_usize()
+    }
+
+    /// Consumes `self`, returning a serialized representation.
+    ///
+    /// The output is faithful to the SSZ encoding of `self`, such that a leading `true` bit is
+    /// used to indicate the length of the bitfield.
+    ///
+    /// ## Example
+    /// ```
+    /// use ssz_types::{BitList, typenum};
+    ///
+    /// type BitList8 = BitList<typenum::U8>;
+    ///
+    /// let b = BitList8::with_capacity(4).unwrap();
+    ///
+    /// assert_eq!(b.into_bytes(), vec![0b0001_0000]);
+    /// ```
+    pub fn into_bytes(self) -> Vec<u8> {
+        let len = self.len();
+        let mut bytes = self.bytes;
+
+        bytes.resize(bytes_for_bit_len(len + 1), 0);
+
+        let mut bitfield: Bitfield<Variable<N>> = Bitfield::from_raw_bytes(bytes, len + 1)
+            .unwrap_or_else(|_| {
+                unreachable!(
+                    "Bitfield with {} bytes must have enough capacity for {} bits.",
+                    bytes_for_bit_len(len + 1),
+                    len + 1
+                )
+            });
+        bitfield
+            .set(len, true)
+            .expect("len must be in bounds for bitfield.");
+
+        bitfield.bytes
+    }
+
+    /// Instantiates a new instance from `bytes`. Consumes the same format that `self.into_bytes()`
+    /// produces (SSZ).
+    ///
+    /// Returns `None` if `bytes` are not a valid encoding.
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, Error> {
+        let bytes_len = bytes.len();
+        let mut initial_bitfield: Bitfield<Variable<N>> = {
+            let num_bits = bytes.len() * 8;
+            Bitfield::from_raw_bytes(bytes, num_bits)?
+        };
+
+        let len = initial_bitfield
+            .highest_set_bit()
+            .ok_or_else(|| Error::MissingLengthInformation)?;
+
+        // The length bit should be in the last byte, or else it means we have too many bytes.
+        if len / 8 + 1 != bytes_len {
+            return Err(Error::InvalidByteCount {
+                given: bytes_len,
+                expected: len / 8 + 1,
+            });
+        }
+
+        if len <= Self::max_len() {
+            initial_bitfield
+                .set(len, false)
+                .expect("Bit has been confirmed to exist");
+
+            let mut bytes = initial_bitfield.into_raw_bytes();
+
+            bytes.truncate(bytes_for_bit_len(len));
+
+            Self::from_raw_bytes(bytes, len)
+        } else {
+            Err(Error::OutOfBounds {
+                i: Self::max_len(),
+                len: Self::max_len(),
+            })
+        }
+    }
+
+    /// Compute the intersection of two BitLists of potentially different lengths.
+    ///
+    /// Return a new BitList with length equal to the shorter of the two inputs.
+    pub fn intersection(&self, other: &Self) -> Self {
+        let min_len = std::cmp::min(self.len(), other.len());
+        let mut result = Self::with_capacity(min_len).expect("min len always less than N");
+        // Bitwise-and the bytes together, starting from the left of each vector. This takes care
+        // of masking out any entries beyond `min_len` as well, assuming the bitfield doesn't
+        // contain any set bits beyond its length.
+        for i in 0..result.bytes.len() {
+            result.bytes[i] = self.bytes[i] & other.bytes[i];
+        }
+        result
+    }
+
+    /// Compute the union of two BitLists of potentially different lengths.
+    ///
+    /// Return a new BitList with length equal to the longer of the two inputs.
+    pub fn union(&self, other: &Self) -> Self {
+        let max_len = std::cmp::max(self.len(), other.len());
+        let mut result = Self::with_capacity(max_len).expect("max len always less than N");
+        for i in 0..result.bytes.len() {
+            result.bytes[i] =
+                self.bytes.get(i).copied().unwrap_or(0) | other.bytes.get(i).copied().unwrap_or(0);
+        }
+        result
+    }
+}
+
+impl<N: Unsigned + Clone> Bitfield<Fixed<N>> {
+    /// Instantiate a new `Bitfield` with a fixed-length of `N` bits.
+    ///
+    /// All bits are initialized to `false`.
+    pub fn new() -> Self {
+        Self {
+            bytes: vec![0; bytes_for_bit_len(Self::capacity())],
+            len: Self::capacity(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Returns `N`, the number of bits in `Self`.
+    pub fn capacity() -> usize {
+        N::to_usize()
+    }
+
+    /// Consumes `self`, returning a serialized representation.
+    ///
+    /// The output is faithful to the SSZ encoding of `self`.
+    ///
+    /// ## Example
+    /// ```
+    /// use ssz_types::{BitVector, typenum};
+    ///
+    /// type BitVector4 = BitVector<typenum::U4>;
+    ///
+    /// assert_eq!(BitVector4::new().into_bytes(), vec![0b0000_0000]);
+    /// ```
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.into_raw_bytes()
+    }
+
+    /// Instantiates a new instance from `bytes`. Consumes the same format that `self.into_bytes()`
+    /// produces (SSZ).
+    ///
+    /// Returns `None` if `bytes` are not a valid encoding.
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, Error> {
+        Self::from_raw_bytes(bytes, Self::capacity())
+    }
+}
+
+impl<N: Unsigned + Clone> Default for Bitfield<Fixed<N>> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: BitfieldBehaviour> Bitfield<T> {
+    /// Sets the `i`'th bit to `value`.
+    ///
+    /// Returns `None` if `i` is out-of-bounds of `self`.
+    pub fn set(&mut self, i: usize, value: bool) -> Result<(), Error> {
+        let len = self.len;
+
+        if i < len {
+            let byte = self
+                .bytes
+                .get_mut(i / 8)
+                .ok_or_else(|| Error::OutOfBounds { i, len })?;
+
+            if value {
+                *byte |= 1 << (i % 8)
+            } else {
+                *byte &= !(1 << (i % 8))
+            }
+
+            Ok(())
+        } else {
+            Err(Error::OutOfBounds { i, len: self.len })
+        }
+    }
+
+    /// Returns the value of the `i`'th bit.
+    ///
+    /// Returns `None` if `i` is out-of-bounds of `self`.
+    pub fn get(&self, i: usize) -> Result<bool, Error> {
+        if i < self.len {
+            let byte = self
+                .bytes
+                .get(i / 8)
+                .ok_or_else(|| Error::OutOfBounds { i, len: self.len })?;
+
+            Ok(*byte & 1 << (i % 8) > 0)
+        } else {
+            Err(Error::OutOfBounds { i, len: self.len })
+        }
+    }
+
+    /// Returns the number of bits stored in `self`.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if `self.len() == 0`.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the underlying bytes representation of the bitfield.
+    pub fn into_raw_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    /// Returns a view into the underlying bytes representation of the bitfield.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Instantiates from the given `bytes`, which are the same format as output from
+    /// `self.into_raw_bytes()`.
+    ///
+    /// Returns `None` if:
+    ///
+    /// - `bytes` is not the minimal required bytes to represent a bitfield of `bit_len` bits.
+    /// - `bit_len` is not a multiple of 8 and `bytes` contains set bits that are higher than, or
+    /// equal to `bit_len`.
+    fn from_raw_bytes(bytes: Vec<u8>, bit_len: usize) -> Result<Self, Error> {
+        if bit_len == 0 {
+            if bytes.len() == 1 && bytes == [0] {
+                // A bitfield with `bit_len` 0 can only be represented by a single zero byte.
+                Ok(Self {
+                    bytes,
+                    len: 0,
+                    _phantom: PhantomData,
+                })
+            } else {
+                Err(Error::ExcessBits)
+            }
+        } else if bytes.len() != bytes_for_bit_len(bit_len) {
+            // The number of bytes must be the minimum required to represent `bit_len`.
+            Err(Error::InvalidByteCount {
+                given: bytes.len(),
+                expected: bytes_for_bit_len(bit_len),
+            })
+        } else {
+            // Ensure there are no bits higher than `bit_len` that are set to true.
+            let (mask, _) = u8::max_value().overflowing_shr(8 - (bit_len as u32 % 8));
+
+            if (bytes.last().expect("Guarded against empty bytes") & !mask) == 0 {
+                Ok(Self {
+                    bytes,
+                    len: bit_len,
+                    _phantom: PhantomData,
+                })
+            } else {
+                Err(Error::ExcessBits)
+            }
+        }
+    }
+
+    /// Returns the `Some(i)` where `i` is the highest index with a set bit. Returns `None` if
+    /// there are no set bits.
+    pub fn highest_set_bit(&self) -> Option<usize> {
+        self.bytes
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, byte)| **byte > 0)
+            .map(|(i, byte)| i * 8 + 7 - byte.leading_zeros() as usize)
+    }
+
+    /// Returns an iterator across bitfield `bool` values, starting at the lowest index.
+    pub fn iter(&self) -> BitIter<'_, T> {
+        BitIter {
+            bitfield: self,
+            i: 0,
+        }
+    }
+
+    /// Returns true if no bits are set.
+    pub fn is_zero(&self) -> bool {
+        self.bytes.iter().all(|byte| *byte == 0)
+    }
+
+    /// Returns the number of bits that are set to `true`.
+    pub fn num_set_bits(&self) -> usize {
+        self.bytes
+            .iter()
+            .map(|byte| byte.count_ones() as usize)
+            .sum()
+    }
+
+    /// Compute the difference of this Bitfield and another of potentially different length.
+    pub fn difference(&self, other: &Self) -> Self {
+        let mut result = self.clone();
+        result.difference_inplace(other);
+        result
+    }
+
+    /// Compute the difference of this Bitfield and another of potentially different length.
+    pub fn difference_inplace(&mut self, other: &Self) {
+        let min_byte_len = std::cmp::min(self.bytes.len(), other.bytes.len());
+
+        for i in 0..min_byte_len {
+            self.bytes[i] &= !other.bytes[i];
+        }
+    }
+
+    /// Shift the bits to higher indices, filling the lower indices with zeroes.
+    ///
+    /// The amount to shift by, `n`, must be less than or equal to `self.len()`.
+    pub fn shift_up(&mut self, n: usize) -> Result<(), Error> {
+        if n <= self.len() {
+            // Shift the bits up (starting from the high indices to avoid overwriting)
+            for i in (n..self.len()).rev() {
+                self.set(i, self.get(i - n)?)?;
+            }
+            // Zero the low bits
+            for i in 0..n {
+                self.set(i, false).unwrap();
+            }
+            Ok(())
+        } else {
+            Err(Error::OutOfBounds {
+                i: n,
+                len: self.len(),
+            })
+        }
+    }
+}
+
+/// Returns the minimum required bytes to represent a given number of bits.
+///
+/// `bit_len == 0` requires a single byte.
+fn bytes_for_bit_len(bit_len: usize) -> usize {
+    std::cmp::max(1, (bit_len + 7) / 8)
+}
+
+/// An iterator over the bits in a `Bitfield`.
+pub struct BitIter<'a, T> {
+    bitfield: &'a Bitfield<T>,
+    i: usize,
+}
+
+impl<'a, T: BitfieldBehaviour> Iterator for BitIter<'a, T> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let res = self.bitfield.get(self.i).ok()?;
+        self.i += 1;
+        Some(res)
+    }
+}
+
+impl<N: Unsigned + Clone> Encode for Bitfield<Variable<N>> {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+//    fn ssz_bytes_len(&self) -> usize {
+//        // We could likely do better than turning this into bytes and reading the length, however
+//        // it is kept this way for simplicity.
+//        self.clone().into_bytes().len()
+//    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        buf.append(&mut self.clone().into_bytes())
+    }
+}
+
+impl<N: Unsigned + Clone> Decode for Bitfield<Variable<N>> {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        Self::from_bytes(bytes.to_vec()).map_err(|e| {
+            ssz::DecodeError::BytesInvalid(format!("BitList failed to decode: {:?}", e))
+        })
+    }
+}
+
+impl<N: Unsigned + Clone> Encode for Bitfield<Fixed<N>> {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+//    fn ssz_bytes_len(&self) -> usize {
+//        self.as_slice().len()
+//    }
+
+    fn ssz_fixed_len() -> usize {
+        bytes_for_bit_len(N::to_usize())
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        buf.append(&mut self.clone().into_bytes())
+    }
+}
+
+impl<N: Unsigned + Clone> Decode for Bitfield<Fixed<N>> {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        bytes_for_bit_len(N::to_usize())
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        Self::from_bytes(bytes.to_vec()).map_err(|e| {
+            ssz::DecodeError::BytesInvalid(format!("BitVector failed to decode: {:?}", e))
+        })
+    }
+}
+
+impl<N: Unsigned + Clone> Serialize for Bitfield<Variable<N>> {
+    /// Serde serialization is compliant with the Ethereum YAML test format.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        serializer.serialize_str(&hex_encode(self.as_ssz_bytes()))
+    }
+}
+
+impl<'de, N: Unsigned + Clone> Deserialize<'de> for Bitfield<Variable<N>> {
+    /// Serde serialization is compliant with the Ethereum YAML test format.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        let bytes = deserializer.deserialize_str(PrefixedHexVisitor)?;
+        Self::from_ssz_bytes(&bytes)
+            .map_err(|e| serde::de::Error::custom(format!("Bitfield {:?}", e)))
+    }
+}
+
+impl<N: Unsigned + Clone> Serialize for Bitfield<Fixed<N>> {
+    /// Serde serialization is compliant with the Ethereum YAML test format.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        serializer.serialize_str(&hex_encode(self.as_ssz_bytes()))
+    }
+}
+
+impl<'de, N: Unsigned + Clone> Deserialize<'de> for Bitfield<Fixed<N>> {
+    /// Serde serialization is compliant with the Ethereum YAML test format.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        let bytes = deserializer.deserialize_str(PrefixedHexVisitor)?;
+        Self::from_ssz_bytes(&bytes)
+            .map_err(|e| serde::de::Error::custom(format!("Bitfield {:?}", e)))
+    }
+}
+
+impl<N: Unsigned + Clone> tree_hash::TreeHash for Bitfield<Variable<N>> {
+    fn tree_hash_type() -> tree_hash::TreeHashType {
+        tree_hash::TreeHashType::List
+    }
+
+    fn tree_hash_packed_encoding(&self) -> Vec<u8> {
+        unreachable!("List should never be packed.")
+    }
+
+    fn tree_hash_packing_factor() -> usize {
+        unreachable!("List should never be packed.")
+    }
+
+    fn tree_hash_root(&self) -> Vec<u8> {
+        // Note: we use `as_slice` because it does _not_ have the length-delimiting bit set (or
+        // present).
+        let root = bitfield_bytes_tree_hash_root::<N>(self.as_slice());
+        tree_hash::mix_in_length(&root, self.len())
+    }
+}
+
+impl<N: Unsigned + Clone> tree_hash::TreeHash for Bitfield<Fixed<N>> {
+    fn tree_hash_type() -> tree_hash::TreeHashType {
+        tree_hash::TreeHashType::Vector
+    }
+
+    fn tree_hash_packed_encoding(&self) -> Vec<u8> {
+        unreachable!("Vector should never be packed.")
+    }
+
+    fn tree_hash_packing_factor() -> usize {
+        unreachable!("Vector should never be packed.")
+    }
+
+    fn tree_hash_root(&self) -> Vec<u8> {
+        bitfield_bytes_tree_hash_root::<N>(self.as_slice())
+    }
+}
+
+#[cfg(test)]
+mod bitvector {
+    use super::*;
+    use crate::BitVector;
+
+    pub type BitVector0 = BitVector<typenum::U0>;
+    pub type BitVector1 = BitVector<typenum::U1>;
+    pub type BitVector4 = BitVector<typenum::U4>;
+    pub type BitVector8 = BitVector<typenum::U8>;
+    pub type BitVector16 = BitVector<typenum::U16>;
+    pub type BitVector64 = BitVector<typenum::U64>;
+
+    #[test]
+    fn ssz_encode() {
+        assert_eq!(BitVector0::new().as_ssz_bytes(), vec![0b0000_0000]);
+        assert_eq!(BitVector1::new().as_ssz_bytes(), vec![0b0000_0000]);
+        assert_eq!(BitVector4::new().as_ssz_bytes(), vec![0b0000_0000]);
+        assert_eq!(BitVector8::new().as_ssz_bytes(), vec![0b0000_0000]);
+        assert_eq!(
+            BitVector16::new().as_ssz_bytes(),
+            vec![0b0000_0000, 0b0000_0000]
+        );
+
+        let mut b = BitVector8::new();
+        for i in 0..8 {
+            b.set(i, true).unwrap();
+        }
+        assert_eq!(b.as_ssz_bytes(), vec![255]);
+
+        let mut b = BitVector4::new();
+        for i in 0..4 {
+            b.set(i, true).unwrap();
+        }
+        assert_eq!(b.as_ssz_bytes(), vec![0b0000_1111]);
+    }
+
+    #[test]
+    fn ssz_decode() {
+        assert!(BitVector0::from_ssz_bytes(&[0b0000_0000]).is_ok());
+        assert!(BitVector0::from_ssz_bytes(&[0b0000_0001]).is_err());
+        assert!(BitVector0::from_ssz_bytes(&[0b0000_0010]).is_err());
+
+        assert!(BitVector1::from_ssz_bytes(&[0b0000_0001]).is_ok());
+        assert!(BitVector1::from_ssz_bytes(&[0b0000_0010]).is_err());
+        assert!(BitVector1::from_ssz_bytes(&[0b0000_0100]).is_err());
+        assert!(BitVector1::from_ssz_bytes(&[0b0000_0000, 0b0000_0000]).is_err());
+
+        assert!(BitVector8::from_ssz_bytes(&[0b0000_0000]).is_ok());
+        assert!(BitVector8::from_ssz_bytes(&[1, 0b0000_0000]).is_err());
+        assert!(BitVector8::from_ssz_bytes(&[0b0000_0000, 1]).is_err());
+        assert!(BitVector8::from_ssz_bytes(&[0b0000_0001]).is_ok());
+        assert!(BitVector8::from_ssz_bytes(&[0b0000_0010]).is_ok());
+        assert!(BitVector8::from_ssz_bytes(&[0b0000_0100, 0b0000_0001]).is_err());
+        assert!(BitVector8::from_ssz_bytes(&[0b0000_0100, 0b0000_0010]).is_err());
+        assert!(BitVector8::from_ssz_bytes(&[0b0000_0100, 0b0000_0100]).is_err());
+
+        assert!(BitVector16::from_ssz_bytes(&[0b0000_0000]).is_err());
+        assert!(BitVector16::from_ssz_bytes(&[0b0000_0000, 0b0000_0000]).is_ok());
+        assert!(BitVector16::from_ssz_bytes(&[1, 0b0000_0000, 0b0000_0000]).is_err());
+    }
+
+    #[test]
+    fn ssz_round_trip() {
+        assert_round_trip(BitVector0::new());
+
+        let mut b = BitVector1::new();
+        b.set(0, true).unwrap();
+        assert_round_trip(b);
+
+        let mut b = BitVector8::new();
+        for j in 0..8 {
+            if j % 2 == 0 {
+                b.set(j, true).unwrap();
+            }
+        }
+        assert_round_trip(b);
+
+        let mut b = BitVector8::new();
+        for j in 0..8 {
+            b.set(j, true).unwrap();
+        }
+        assert_round_trip(b);
+
+        let mut b = BitVector16::new();
+        for j in 0..16 {
+            if j % 2 == 0 {
+                b.set(j, true).unwrap();
+            }
+        }
+        assert_round_trip(b);
+
+        let mut b = BitVector16::new();
+        for j in 0..16 {
+            b.set(j, true).unwrap();
+        }
+        assert_round_trip(b);
+    }
+
+    fn assert_round_trip<T: Encode + Decode + PartialEq + std::fmt::Debug>(t: T) {
+        assert_eq!(T::from_ssz_bytes(&t.as_ssz_bytes()).unwrap(), t);
+    }
+
+//    #[test]
+//    fn ssz_bytes_len() {
+//        for i in 0..64 {
+//            let mut bitfield = BitVector64::new();
+//            for j in 0..i {
+//                bitfield.set(j, true).expect("should set bit in bounds");
+//            }
+//            let bytes = bitfield.as_ssz_bytes();
+//            assert_eq!(bitfield.ssz_bytes_len(), bytes.len(), "i = {}", i);
+//        }
+//    }
+
+    #[test]
+    fn excess_bits_nimbus() {
+        let bad = vec![0b0001_1111];
+
+        assert!(BitVector4::from_ssz_bytes(&bad).is_err());
+    }
+}
+
+#[cfg(test)]
+mod bitlist {
+    use super::*;
+    use crate::BitList;
+
+    pub type BitList0 = BitList<typenum::U0>;
+    pub type BitList1 = BitList<typenum::U1>;
+    pub type BitList8 = BitList<typenum::U8>;
+    pub type BitList16 = BitList<typenum::U16>;
+    pub type BitList1024 = BitList<typenum::U1024>;
+
+    #[test]
+    fn ssz_encode() {
+        assert_eq!(
+            BitList0::with_capacity(0).unwrap().as_ssz_bytes(),
+            vec![0b0000_00001],
+        );
+
+        assert_eq!(
+            BitList1::with_capacity(0).unwrap().as_ssz_bytes(),
+            vec![0b0000_00001],
+        );
+
+        assert_eq!(
+            BitList1::with_capacity(1).unwrap().as_ssz_bytes(),
+            vec![0b0000_00010],
+        );
+
+        assert_eq!(
+            BitList8::with_capacity(8).unwrap().as_ssz_bytes(),
+            vec![0b0000_0000, 0b0000_0001],
+        );
+
+        assert_eq!(
+            BitList8::with_capacity(7).unwrap().as_ssz_bytes(),
+            vec![0b1000_0000]
+        );
+
+        let mut b = BitList8::with_capacity(8).unwrap();
+        for i in 0..8 {
+            b.set(i, true).unwrap();
+        }
+        assert_eq!(b.as_ssz_bytes(), vec![255, 0b0000_0001]);
+
+        let mut b = BitList8::with_capacity(8).unwrap();
+        for i in 0..4 {
+            b.set(i, true).unwrap();
+        }
+        assert_eq!(b.as_ssz_bytes(), vec![0b0000_1111, 0b0000_0001]);
+
+        assert_eq!(
+            BitList16::with_capacity(16).unwrap().as_ssz_bytes(),
+            vec![0b0000_0000, 0b0000_0000, 0b0000_0001]
+        );
+    }
+
+    #[test]
+    fn ssz_decode() {
+        assert!(BitList0::from_ssz_bytes(&[]).is_err());
+        assert!(BitList1::from_ssz_bytes(&[]).is_err());
+        assert!(BitList8::from_ssz_bytes(&[]).is_err());
+        assert!(BitList16::from_ssz_bytes(&[]).is_err());
+
+        assert!(BitList0::from_ssz_bytes(&[0b0000_0000]).is_err());
+        assert!(BitList1::from_ssz_bytes(&[0b0000_0000, 0b0000_0000]).is_err());
+        assert!(BitList8::from_ssz_bytes(&[0b0000_0000]).is_err());
+        assert!(BitList16::from_ssz_bytes(&[0b0000_0000]).is_err());
+
+        assert!(BitList0::from_ssz_bytes(&[0b0000_0001]).is_ok());
+        assert!(BitList0::from_ssz_bytes(&[0b0000_0010]).is_err());
+
+        assert!(BitList1::from_ssz_bytes(&[0b0000_0001]).is_ok());
+        assert!(BitList1::from_ssz_bytes(&[0b0000_0010]).is_ok());
+        assert!(BitList1::from_ssz_bytes(&[0b0000_0100]).is_err());
+
+        assert!(BitList8::from_ssz_bytes(&[0b0000_0001]).is_ok());
+        assert!(BitList8::from_ssz_bytes(&[0b0000_0010]).is_ok());
+        assert!(BitList8::from_ssz_bytes(&[0b0000_0001, 0b0000_0001]).is_ok());
+        assert!(BitList8::from_ssz_bytes(&[0b0000_0001, 0b0000_0010]).is_err());
+        assert!(BitList8::from_ssz_bytes(&[0b0000_0001, 0b0000_0100]).is_err());
+    }
+
+    #[test]
+    fn ssz_decode_extra_bytes() {
+        assert!(BitList0::from_ssz_bytes(&[0b0000_0001, 0b0000_0000]).is_err());
+        assert!(BitList1::from_ssz_bytes(&[0b0000_0001, 0b0000_0000]).is_err());
+        assert!(BitList8::from_ssz_bytes(&[0b0000_0001, 0b0000_0000]).is_err());
+        assert!(BitList16::from_ssz_bytes(&[0b0000_0001, 0b0000_0000]).is_err());
+        assert!(BitList1024::from_ssz_bytes(&[0b1000_0000, 0]).is_err());
+        assert!(BitList1024::from_ssz_bytes(&[0b1000_0000, 0, 0]).is_err());
+        assert!(BitList1024::from_ssz_bytes(&[0b1000_0000, 0, 0, 0, 0]).is_err());
+    }
+
+    #[test]
+    fn ssz_round_trip() {
+        assert_round_trip(BitList0::with_capacity(0).unwrap());
+
+        for i in 0..2 {
+            assert_round_trip(BitList1::with_capacity(i).unwrap());
+        }
+        for i in 0..9 {
+            assert_round_trip(BitList8::with_capacity(i).unwrap());
+        }
+        for i in 0..17 {
+            assert_round_trip(BitList16::with_capacity(i).unwrap());
+        }
+
+        let mut b = BitList1::with_capacity(1).unwrap();
+        b.set(0, true).unwrap();
+        assert_round_trip(b);
+
+        for i in 0..8 {
+            let mut b = BitList8::with_capacity(i).unwrap();
+            for j in 0..i {
+                if j % 2 == 0 {
+                    b.set(j, true).unwrap();
+                }
+            }
+            assert_round_trip(b);
+
+            let mut b = BitList8::with_capacity(i).unwrap();
+            for j in 0..i {
+                b.set(j, true).unwrap();
+            }
+            assert_round_trip(b);
+        }
+
+        for i in 0..16 {
+            let mut b = BitList16::with_capacity(i).unwrap();
+            for j in 0..i {
+                if j % 2 == 0 {
+                    b.set(j, true).unwrap();
+                }
+            }
+            assert_round_trip(b);
+
+            let mut b = BitList16::with_capacity(i).unwrap();
+            for j in 0..i {
+                b.set(j, true).unwrap();
+            }
+            assert_round_trip(b);
+        }
+    }
+
+    fn assert_round_trip<T: Encode + Decode + PartialEq + std::fmt::Debug>(t: T) {
+        assert_eq!(T::from_ssz_bytes(&t.as_ssz_bytes()).unwrap(), t);
+    }
+
+    #[test]
+    fn from_raw_bytes() {
+        assert!(BitList1024::from_raw_bytes(vec![0b0000_0000], 0).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b0000_0001], 1).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b0000_0011], 2).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b0000_0111], 3).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b0000_1111], 4).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b0001_1111], 5).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b0011_1111], 6).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b0111_1111], 7).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111], 8).is_ok());
+
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0000_0001], 9).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0000_0011], 10).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0000_0111], 11).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0000_1111], 12).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0001_1111], 13).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0011_1111], 14).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0111_1111], 15).is_ok());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b1111_1111], 16).is_ok());
+
+        for i in 0..8 {
+            assert!(BitList1024::from_raw_bytes(vec![], i).is_err());
+            assert!(BitList1024::from_raw_bytes(vec![0b1111_1111], i).is_err());
+            assert!(BitList1024::from_raw_bytes(vec![0b0000_0000, 0b1111_1110], i).is_err());
+        }
+
+        assert!(BitList1024::from_raw_bytes(vec![0b0000_0001], 0).is_err());
+
+        assert!(BitList1024::from_raw_bytes(vec![0b0000_0001], 0).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b0000_0011], 1).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b0000_0111], 2).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b0000_1111], 3).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b0001_1111], 4).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b0011_1111], 5).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b0111_1111], 6).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111], 7).is_err());
+
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0000_0001], 8).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0000_0011], 9).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0000_0111], 10).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0000_1111], 11).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0001_1111], 12).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0011_1111], 13).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b0111_1111], 14).is_err());
+        assert!(BitList1024::from_raw_bytes(vec![0b1111_1111, 0b1111_1111], 15).is_err());
+    }
+
+    fn test_set_unset(num_bits: usize) {
+        let mut bitfield = BitList1024::with_capacity(num_bits).unwrap();
+
+        for i in 0..num_bits + 1 {
+            if i < num_bits {
+                // Starts as false
+                assert_eq!(bitfield.get(i), Ok(false));
+                // Can be set true.
+                assert!(bitfield.set(i, true).is_ok());
+                assert_eq!(bitfield.get(i), Ok(true));
+                // Can be set false
+                assert!(bitfield.set(i, false).is_ok());
+                assert_eq!(bitfield.get(i), Ok(false));
+            } else {
+                assert!(bitfield.get(i).is_err());
+                assert!(bitfield.set(i, true).is_err());
+                assert!(bitfield.get(i).is_err());
+            }
+        }
+    }
+
+    fn test_bytes_round_trip(num_bits: usize) {
+        for i in 0..num_bits {
+            let mut bitfield = BitList1024::with_capacity(num_bits).unwrap();
+            bitfield.set(i, true).unwrap();
+
+            let bytes = bitfield.clone().into_raw_bytes();
+            assert_eq!(bitfield, Bitfield::from_raw_bytes(bytes, num_bits).unwrap());
+        }
+    }
+
+    #[test]
+    fn set_unset() {
+        for i in 0..8 * 5 {
+            test_set_unset(i)
+        }
+    }
+
+    #[test]
+    fn bytes_round_trip() {
+        for i in 0..8 * 5 {
+            test_bytes_round_trip(i)
+        }
+    }
+
+    #[test]
+    fn into_raw_bytes() {
+        let mut bitfield = BitList1024::with_capacity(9).unwrap();
+        bitfield.set(0, true).unwrap();
+        assert_eq!(
+            bitfield.clone().into_raw_bytes(),
+            vec![0b0000_0001, 0b0000_0000]
+        );
+        bitfield.set(1, true).unwrap();
+        assert_eq!(
+            bitfield.clone().into_raw_bytes(),
+            vec![0b0000_0011, 0b0000_0000]
+        );
+        bitfield.set(2, true).unwrap();
+        assert_eq!(
+            bitfield.clone().into_raw_bytes(),
+            vec![0b0000_0111, 0b0000_0000]
+        );
+        bitfield.set(3, true).unwrap();
+        assert_eq!(
+            bitfield.clone().into_raw_bytes(),
+            vec![0b0000_1111, 0b0000_0000]
+        );
+        bitfield.set(4, true).unwrap();
+        assert_eq!(
+            bitfield.clone().into_raw_bytes(),
+            vec![0b0001_1111, 0b0000_0000]
+        );
+        bitfield.set(5, true).unwrap();
+        assert_eq!(
+            bitfield.clone().into_raw_bytes(),
+            vec![0b0011_1111, 0b0000_0000]
+        );
+        bitfield.set(6, true).unwrap();
+        assert_eq!(
+            bitfield.clone().into_raw_bytes(),
+            vec![0b0111_1111, 0b0000_0000]
+        );
+        bitfield.set(7, true).unwrap();
+        assert_eq!(
+            bitfield.clone().into_raw_bytes(),
+            vec![0b1111_1111, 0b0000_0000]
+        );
+        bitfield.set(8, true).unwrap();
+        assert_eq!(
+            bitfield.clone().into_raw_bytes(),
+            vec![0b1111_1111, 0b0000_0001]
+        );
+    }
+
+    #[test]
+    fn highest_set_bit() {
+        assert_eq!(
+            BitList1024::with_capacity(16).unwrap().highest_set_bit(),
+            None
+        );
+
+        assert_eq!(
+            BitList1024::from_raw_bytes(vec![0b0000_0001, 0b0000_0000], 16)
+                .unwrap()
+                .highest_set_bit(),
+            Some(0)
+        );
+
+        assert_eq!(
+            BitList1024::from_raw_bytes(vec![0b0000_0010, 0b0000_0000], 16)
+                .unwrap()
+                .highest_set_bit(),
+            Some(1)
+        );
+
+        assert_eq!(
+            BitList1024::from_raw_bytes(vec![0b0000_1000], 8)
+                .unwrap()
+                .highest_set_bit(),
+            Some(3)
+        );
+
+        assert_eq!(
+            BitList1024::from_raw_bytes(vec![0b0000_0000, 0b1000_0000], 16)
+                .unwrap()
+                .highest_set_bit(),
+            Some(15)
+        );
+    }
+
+    #[test]
+    fn intersection() {
+        let a = BitList1024::from_raw_bytes(vec![0b1100, 0b0001], 16).unwrap();
+        let b = BitList1024::from_raw_bytes(vec![0b1011, 0b1001], 16).unwrap();
+        let c = BitList1024::from_raw_bytes(vec![0b1000, 0b0001], 16).unwrap();
+
+        assert_eq!(a.intersection(&b), c);
+        assert_eq!(b.intersection(&a), c);
+        assert_eq!(a.intersection(&c), c);
+        assert_eq!(b.intersection(&c), c);
+        assert_eq!(a.intersection(&a), a);
+        assert_eq!(b.intersection(&b), b);
+        assert_eq!(c.intersection(&c), c);
+    }
+
+    #[test]
+    fn intersection_diff_length() {
+        let a = BitList1024::from_bytes(vec![0b0010_1110, 0b0010_1011]).unwrap();
+        let b = BitList1024::from_bytes(vec![0b0010_1101, 0b0000_0001]).unwrap();
+        let c = BitList1024::from_bytes(vec![0b0010_1100, 0b0000_0001]).unwrap();
+        let d = BitList1024::from_bytes(vec![0b0010_1110, 0b1111_1111, 0b1111_1111]).unwrap();
+
+        assert_eq!(a.len(), 13);
+        assert_eq!(b.len(), 8);
+        assert_eq!(c.len(), 8);
+        assert_eq!(d.len(), 23);
+        assert_eq!(a.intersection(&b), c);
+        assert_eq!(b.intersection(&a), c);
+        assert_eq!(a.intersection(&d), a);
+        assert_eq!(d.intersection(&a), a);
+    }
+
+    #[test]
+    fn union() {
+        let a = BitList1024::from_raw_bytes(vec![0b1100, 0b0001], 16).unwrap();
+        let b = BitList1024::from_raw_bytes(vec![0b1011, 0b1001], 16).unwrap();
+        let c = BitList1024::from_raw_bytes(vec![0b1111, 0b1001], 16).unwrap();
+
+        assert_eq!(a.union(&b), c);
+        assert_eq!(b.union(&a), c);
+        assert_eq!(a.union(&a), a);
+        assert_eq!(b.union(&b), b);
+        assert_eq!(c.union(&c), c);
+    }
+
+    #[test]
+    fn union_diff_length() {
+        let a = BitList1024::from_bytes(vec![0b0010_1011, 0b0010_1110]).unwrap();
+        let b = BitList1024::from_bytes(vec![0b0000_0001, 0b0010_1101]).unwrap();
+        let c = BitList1024::from_bytes(vec![0b0010_1011, 0b0010_1111]).unwrap();
+        let d = BitList1024::from_bytes(vec![0b0010_1011, 0b1011_1110, 0b1000_1101]).unwrap();
+
+        assert_eq!(a.len(), c.len());
+        assert_eq!(a.union(&b), c);
+        assert_eq!(b.union(&a), c);
+        assert_eq!(a.union(&d), d);
+        assert_eq!(d.union(&a), d);
+    }
+
+    #[test]
+    fn difference() {
+        let a = BitList1024::from_raw_bytes(vec![0b1100, 0b0001], 16).unwrap();
+        let b = BitList1024::from_raw_bytes(vec![0b1011, 0b1001], 16).unwrap();
+        let a_b = BitList1024::from_raw_bytes(vec![0b0100, 0b0000], 16).unwrap();
+        let b_a = BitList1024::from_raw_bytes(vec![0b0011, 0b1000], 16).unwrap();
+
+        assert_eq!(a.difference(&b), a_b);
+        assert_eq!(b.difference(&a), b_a);
+        assert!(a.difference(&a).is_zero());
+    }
+
+    #[test]
+    fn difference_diff_length() {
+        let a = BitList1024::from_raw_bytes(vec![0b0110, 0b1100, 0b0011], 24).unwrap();
+        let b = BitList1024::from_raw_bytes(vec![0b1011, 0b1001], 16).unwrap();
+        let a_b = BitList1024::from_raw_bytes(vec![0b0100, 0b0100, 0b0011], 24).unwrap();
+        let b_a = BitList1024::from_raw_bytes(vec![0b1001, 0b0001], 16).unwrap();
+
+        assert_eq!(a.difference(&b), a_b);
+        assert_eq!(b.difference(&a), b_a);
+    }
+
+    #[test]
+    fn shift_up() {
+        let mut a = BitList1024::from_raw_bytes(vec![0b1100_1111, 0b1101_0110], 16).unwrap();
+        let mut b = BitList1024::from_raw_bytes(vec![0b1001_1110, 0b1010_1101], 16).unwrap();
+
+        a.shift_up(1).unwrap();
+        assert_eq!(a, b);
+        a.shift_up(15).unwrap();
+        assert!(a.is_zero());
+
+        b.shift_up(16).unwrap();
+        assert!(b.is_zero());
+        assert!(b.shift_up(17).is_err());
+    }
+
+    #[test]
+    fn num_set_bits() {
+        let a = BitList1024::from_raw_bytes(vec![0b1100, 0b0001], 16).unwrap();
+        let b = BitList1024::from_raw_bytes(vec![0b1011, 0b1001], 16).unwrap();
+
+        assert_eq!(a.num_set_bits(), 3);
+        assert_eq!(b.num_set_bits(), 5);
+    }
+
+    #[test]
+    fn iter() {
+        let mut bitfield = BitList1024::with_capacity(9).unwrap();
+        bitfield.set(2, true).unwrap();
+        bitfield.set(8, true).unwrap();
+
+        assert_eq!(
+            bitfield.iter().collect::<Vec<bool>>(),
+            vec![false, false, true, false, false, false, false, false, true]
+        );
+    }
+
+//    #[test]
+//    fn ssz_bytes_len() {
+//        for i in 1..64 {
+//            let mut bitfield = BitList1024::with_capacity(i).unwrap();
+//            for j in 0..i {
+//                bitfield.set(j, true).expect("should set bit in bounds");
+//            }
+//            let bytes = bitfield.as_ssz_bytes();
+//            assert_eq!(bitfield.ssz_bytes_len(), bytes.len(), "i = {}", i);
+//        }
+//    }
+}

--- a/eth2/utils/ssz_types/src/bitfield.rs
+++ b/eth2/utils/ssz_types/src/bitfield.rs
@@ -477,11 +477,11 @@ impl<N: Unsigned + Clone> Encode for Bitfield<Variable<N>> {
         false
     }
 
-//    fn ssz_bytes_len(&self) -> usize {
-//        // We could likely do better than turning this into bytes and reading the length, however
-//        // it is kept this way for simplicity.
-//        self.clone().into_bytes().len()
-//    }
+    //    fn ssz_bytes_len(&self) -> usize {
+    //        // We could likely do better than turning this into bytes and reading the length, however
+    //        // it is kept this way for simplicity.
+    //        self.clone().into_bytes().len()
+    //    }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
         buf.append(&mut self.clone().into_bytes())
@@ -505,9 +505,9 @@ impl<N: Unsigned + Clone> Encode for Bitfield<Fixed<N>> {
         true
     }
 
-//    fn ssz_bytes_len(&self) -> usize {
-//        self.as_slice().len()
-//    }
+    //    fn ssz_bytes_len(&self) -> usize {
+    //        self.as_slice().len()
+    //    }
 
     fn ssz_fixed_len() -> usize {
         bytes_for_bit_len(N::to_usize())
@@ -537,8 +537,8 @@ impl<N: Unsigned + Clone> Decode for Bitfield<Fixed<N>> {
 impl<N: Unsigned + Clone> Serialize for Bitfield<Variable<N>> {
     /// Serde serialization is compliant with the Ethereum YAML test format.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&hex_encode(self.as_ssz_bytes()))
     }
@@ -547,8 +547,8 @@ impl<N: Unsigned + Clone> Serialize for Bitfield<Variable<N>> {
 impl<'de, N: Unsigned + Clone> Deserialize<'de> for Bitfield<Variable<N>> {
     /// Serde serialization is compliant with the Ethereum YAML test format.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let bytes = deserializer.deserialize_str(PrefixedHexVisitor)?;
         Self::from_ssz_bytes(&bytes)
@@ -559,8 +559,8 @@ impl<'de, N: Unsigned + Clone> Deserialize<'de> for Bitfield<Variable<N>> {
 impl<N: Unsigned + Clone> Serialize for Bitfield<Fixed<N>> {
     /// Serde serialization is compliant with the Ethereum YAML test format.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&hex_encode(self.as_ssz_bytes()))
     }
@@ -569,8 +569,8 @@ impl<N: Unsigned + Clone> Serialize for Bitfield<Fixed<N>> {
 impl<'de, N: Unsigned + Clone> Deserialize<'de> for Bitfield<Fixed<N>> {
     /// Serde serialization is compliant with the Ethereum YAML test format.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let bytes = deserializer.deserialize_str(PrefixedHexVisitor)?;
         Self::from_ssz_bytes(&bytes)
@@ -719,17 +719,17 @@ mod bitvector {
         assert_eq!(T::from_ssz_bytes(&t.as_ssz_bytes()).unwrap(), t);
     }
 
-//    #[test]
-//    fn ssz_bytes_len() {
-//        for i in 0..64 {
-//            let mut bitfield = BitVector64::new();
-//            for j in 0..i {
-//                bitfield.set(j, true).expect("should set bit in bounds");
-//            }
-//            let bytes = bitfield.as_ssz_bytes();
-//            assert_eq!(bitfield.ssz_bytes_len(), bytes.len(), "i = {}", i);
-//        }
-//    }
+    //    #[test]
+    //    fn ssz_bytes_len() {
+    //        for i in 0..64 {
+    //            let mut bitfield = BitVector64::new();
+    //            for j in 0..i {
+    //                bitfield.set(j, true).expect("should set bit in bounds");
+    //            }
+    //            let bytes = bitfield.as_ssz_bytes();
+    //            assert_eq!(bitfield.ssz_bytes_len(), bytes.len(), "i = {}", i);
+    //        }
+    //    }
 
     #[test]
     fn excess_bits_nimbus() {
@@ -1184,15 +1184,15 @@ mod bitlist {
         );
     }
 
-//    #[test]
-//    fn ssz_bytes_len() {
-//        for i in 1..64 {
-//            let mut bitfield = BitList1024::with_capacity(i).unwrap();
-//            for j in 0..i {
-//                bitfield.set(j, true).expect("should set bit in bounds");
-//            }
-//            let bytes = bitfield.as_ssz_bytes();
-//            assert_eq!(bitfield.ssz_bytes_len(), bytes.len(), "i = {}", i);
-//        }
-//    }
+    //    #[test]
+    //    fn ssz_bytes_len() {
+    //        for i in 1..64 {
+    //            let mut bitfield = BitList1024::with_capacity(i).unwrap();
+    //            for j in 0..i {
+    //                bitfield.set(j, true).expect("should set bit in bounds");
+    //            }
+    //            let bytes = bitfield.as_ssz_bytes();
+    //            assert_eq!(bitfield.ssz_bytes_len(), bytes.len(), "i = {}", i);
+    //        }
+    //    }
 }

--- a/eth2/utils/ssz_types/src/bitfield.rs
+++ b/eth2/utils/ssz_types/src/bitfield.rs
@@ -1,4 +1,6 @@
-// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+// Copied from the file of the same name in the https://github.com/sigp/lighthouse repo with some
+// modifications and deletions.  Specifically, removed all code not needed for this repo and updated
+// the Encode implementation here to match the Encode trait of the eth2_ssz crate.
 use crate::tree_hash::bitfield_bytes_tree_hash_root;
 use crate::Error;
 use core::marker::PhantomData;

--- a/eth2/utils/ssz_types/src/fixed_vector.rs
+++ b/eth2/utils/ssz_types/src/fixed_vector.rs
@@ -1,0 +1,400 @@
+// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+
+use crate::tree_hash::vec_tree_hash_root;
+use crate::Error;
+use serde_derive::{Deserialize, Serialize};
+use std::marker::PhantomData;
+use std::ops::{Deref, Index, IndexMut};
+use std::slice::SliceIndex;
+use typenum::Unsigned;
+
+pub use typenum;
+
+/// Emulates a SSZ `Vector` (distinct from a Rust `Vec`).
+///
+/// An ordered, heap-allocated, fixed-length, homogeneous collection of `T`, with `N` values.
+///
+/// This struct is backed by a Rust `Vec` but constrained such that it must be instantiated with a
+/// fixed number of elements and you may not add or remove elements, only modify.
+///
+/// The length of this struct is fixed at the type-level using
+/// [typenum](https://crates.io/crates/typenum).
+///
+/// ## Note
+///
+/// Whilst it is possible with this library, SSZ declares that a `FixedVector` with a length of `0`
+/// is illegal.
+///
+/// ## Example
+///
+/// ```
+/// use ssz_types::{FixedVector, typenum};
+///
+/// let base: Vec<u64> = vec![1, 2, 3, 4];
+///
+/// // Create a `FixedVector` from a `Vec` that has the expected length.
+/// let exact: FixedVector<_, typenum::U4> = FixedVector::from(base.clone());
+/// assert_eq!(&exact[..], &[1, 2, 3, 4]);
+///
+/// // Create a `FixedVector` from a `Vec` that is too long and the `Vec` is truncated.
+/// let short: FixedVector<_, typenum::U3> = FixedVector::from(base.clone());
+/// assert_eq!(&short[..], &[1, 2, 3]);
+///
+/// // Create a `FixedVector` from a `Vec` that is too short and the missing values are created
+/// // using `std::default::Default`.
+/// let long: FixedVector<_, typenum::U5> = FixedVector::from(base);
+/// assert_eq!(&long[..], &[1, 2, 3, 4, 0]);
+/// ```
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FixedVector<T, N> {
+    vec: Vec<T>,
+    _phantom: PhantomData<N>,
+}
+
+impl<T, N: Unsigned> FixedVector<T, N> {
+    /// Returns `Ok` if the given `vec` equals the fixed length of `Self`. Otherwise returns
+    /// `Err`.
+    pub fn new(vec: Vec<T>) -> Result<Self, Error> {
+        if vec.len() == Self::capacity() {
+            Ok(Self {
+                vec,
+                _phantom: PhantomData,
+            })
+        } else {
+            Err(Error::OutOfBounds {
+                i: vec.len(),
+                len: Self::capacity(),
+            })
+        }
+    }
+
+    /// Create a new vector filled with clones of `elem`.
+    pub fn from_elem(elem: T) -> Self
+        where
+            T: Clone,
+    {
+        Self {
+            vec: vec![elem; N::to_usize()],
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Identical to `self.capacity`, returns the type-level constant length.
+    ///
+    /// Exists for compatibility with `Vec`.
+    pub fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    /// True if the type-level constant length of `self` is zero.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the type-level constant length.
+    pub fn capacity() -> usize {
+        N::to_usize()
+    }
+}
+
+impl<T: Default, N: Unsigned> From<Vec<T>> for FixedVector<T, N> {
+    fn from(mut vec: Vec<T>) -> Self {
+        vec.resize_with(Self::capacity(), Default::default);
+
+        Self {
+            vec,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, N: Unsigned> Into<Vec<T>> for FixedVector<T, N> {
+    fn into(self) -> Vec<T> {
+        self.vec
+    }
+}
+
+impl<T, N: Unsigned> Default for FixedVector<T, N> {
+    fn default() -> Self {
+        Self {
+            vec: Vec::default(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, N: Unsigned, I: SliceIndex<[T]>> Index<I> for FixedVector<T, N> {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        Index::index(&self.vec, index)
+    }
+}
+
+impl<T, N: Unsigned, I: SliceIndex<[T]>> IndexMut<I> for FixedVector<T, N> {
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        IndexMut::index_mut(&mut self.vec, index)
+    }
+}
+
+impl<T, N: Unsigned> Deref for FixedVector<T, N> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        &self.vec[..]
+    }
+}
+
+impl<T, N: Unsigned> tree_hash::TreeHash for FixedVector<T, N>
+    where
+        T: tree_hash::TreeHash,
+{
+    fn tree_hash_type() -> tree_hash::TreeHashType {
+        tree_hash::TreeHashType::Vector
+    }
+
+    fn tree_hash_packed_encoding(&self) -> Vec<u8> {
+        unreachable!("Vector should never be packed.")
+    }
+
+    fn tree_hash_packing_factor() -> usize {
+        unreachable!("Vector should never be packed.")
+    }
+
+    fn tree_hash_root(&self) -> Vec<u8> {
+        vec_tree_hash_root::<T, N>(&self.vec)
+    }
+}
+
+impl<T, N: Unsigned> ssz::Encode for FixedVector<T, N>
+    where
+        T: ssz::Encode,
+{
+    fn is_ssz_fixed_len() -> bool {
+        T::is_ssz_fixed_len()
+    }
+
+    fn ssz_fixed_len() -> usize {
+        if <Self as ssz::Encode>::is_ssz_fixed_len() {
+            T::ssz_fixed_len() * N::to_usize()
+        } else {
+            ssz::BYTES_PER_LENGTH_OFFSET
+        }
+    }
+
+//    fn ssz_bytes_len(&self) -> usize {
+//        self.vec.ssz_bytes_len()
+//    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        if T::is_ssz_fixed_len() {
+            buf.reserve(T::ssz_fixed_len() * self.len());
+
+            for item in &self.vec {
+                item.ssz_append(buf);
+            }
+        } else {
+            let mut encoder = ssz::SszEncoder::list(buf, self.len() * ssz::BYTES_PER_LENGTH_OFFSET);
+
+            for item in &self.vec {
+                encoder.append(item);
+            }
+
+            encoder.finalize();
+        }
+    }
+}
+
+impl<T, N: Unsigned> ssz::Decode for FixedVector<T, N>
+    where
+        T: ssz::Decode + Default,
+{
+    fn is_ssz_fixed_len() -> bool {
+        T::is_ssz_fixed_len()
+    }
+
+    fn ssz_fixed_len() -> usize {
+        if <Self as ssz::Decode>::is_ssz_fixed_len() {
+            T::ssz_fixed_len() * N::to_usize()
+        } else {
+            ssz::BYTES_PER_LENGTH_OFFSET
+        }
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        if bytes.is_empty() {
+            Err(ssz::DecodeError::InvalidByteLength {
+                len: 0,
+                expected: 1,
+            })
+        } else if T::is_ssz_fixed_len() {
+            bytes
+                .chunks(T::ssz_fixed_len())
+                .map(|chunk| T::from_ssz_bytes(chunk))
+                .collect::<Result<Vec<T>, _>>()
+                .and_then(|vec| {
+                    if vec.len() == N::to_usize() {
+                        Ok(vec.into())
+                    } else {
+                        Err(ssz::DecodeError::BytesInvalid(format!(
+                            "wrong number of vec elements, got: {}, expected: {}",
+                            vec.len(),
+                            N::to_usize()
+                        )))
+                    }
+                })
+        } else {
+            ssz::decode_list_of_variable_length_items(bytes).and_then(|vec| Ok(vec.into()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ssz::*;
+    use tree_hash::{merkle_root, TreeHash};
+    use tree_hash_derive::TreeHash;
+    use typenum::*;
+
+    #[test]
+    fn new() {
+        let vec = vec![42; 5];
+        let fixed: Result<FixedVector<u64, U4>, _> = FixedVector::new(vec.clone());
+        assert!(fixed.is_err());
+
+        let vec = vec![42; 3];
+        let fixed: Result<FixedVector<u64, U4>, _> = FixedVector::new(vec.clone());
+        assert!(fixed.is_err());
+
+        let vec = vec![42; 4];
+        let fixed: Result<FixedVector<u64, U4>, _> = FixedVector::new(vec.clone());
+        assert!(fixed.is_ok());
+    }
+
+    #[test]
+    fn indexing() {
+        let vec = vec![1, 2];
+
+        let mut fixed: FixedVector<u64, U8192> = vec.clone().into();
+
+        assert_eq!(fixed[0], 1);
+        assert_eq!(&fixed[0..1], &vec[0..1]);
+        assert_eq!((&fixed[..]).len(), 8192);
+
+        fixed[1] = 3;
+        assert_eq!(fixed[1], 3);
+    }
+
+    #[test]
+    fn length() {
+        let vec = vec![42; 5];
+        let fixed: FixedVector<u64, U4> = FixedVector::from(vec.clone());
+        assert_eq!(&fixed[..], &vec[0..4]);
+
+        let vec = vec![42; 3];
+        let fixed: FixedVector<u64, U4> = FixedVector::from(vec.clone());
+        assert_eq!(&fixed[0..3], &vec[..]);
+        assert_eq!(&fixed[..], &vec![42, 42, 42, 0][..]);
+
+        let vec = vec![];
+        let fixed: FixedVector<u64, U4> = FixedVector::from(vec.clone());
+        assert_eq!(&fixed[..], &vec![0, 0, 0, 0][..]);
+    }
+
+    #[test]
+    fn deref() {
+        let vec = vec![0, 2, 4, 6];
+        let fixed: FixedVector<u64, U4> = FixedVector::from(vec);
+
+        assert_eq!(fixed.get(0), Some(&0));
+        assert_eq!(fixed.get(3), Some(&6));
+        assert_eq!(fixed.get(4), None);
+    }
+
+    #[test]
+    fn ssz_encode() {
+        let vec: FixedVector<u16, U2> = vec![0; 2].into();
+        assert_eq!(vec.as_ssz_bytes(), vec![0, 0, 0, 0]);
+        assert_eq!(<FixedVector<u16, U2> as Encode>::ssz_fixed_len(), 4);
+    }
+
+    fn ssz_round_trip<T: Encode + Decode + std::fmt::Debug + PartialEq>(item: T) {
+        let encoded = &item.as_ssz_bytes();
+//        assert_eq!(item.ssz_bytes_len(), encoded.len());
+        assert_eq!(T::from_ssz_bytes(&encoded), Ok(item));
+    }
+
+    #[test]
+    fn ssz_round_trip_u16_len_8() {
+        ssz_round_trip::<FixedVector<u16, U8>>(vec![42; 8].into());
+        ssz_round_trip::<FixedVector<u16, U8>>(vec![0; 8].into());
+    }
+
+    #[test]
+    fn tree_hash_u8() {
+        let fixed: FixedVector<u8, U0> = FixedVector::from(vec![]);
+        assert_eq!(fixed.tree_hash_root(), merkle_root(&[0; 8], 0));
+
+        let fixed: FixedVector<u8, U1> = FixedVector::from(vec![0; 1]);
+        assert_eq!(fixed.tree_hash_root(), merkle_root(&[0; 8], 0));
+
+        let fixed: FixedVector<u8, U8> = FixedVector::from(vec![0; 8]);
+        assert_eq!(fixed.tree_hash_root(), merkle_root(&[0; 8], 0));
+
+        let fixed: FixedVector<u8, U16> = FixedVector::from(vec![42; 16]);
+        assert_eq!(fixed.tree_hash_root(), merkle_root(&[42; 16], 0));
+
+        let source: Vec<u8> = (0..16).collect();
+        let fixed: FixedVector<u8, U16> = FixedVector::from(source.clone());
+        assert_eq!(fixed.tree_hash_root(), merkle_root(&source, 0));
+    }
+
+    #[derive(Clone, Copy, TreeHash, Default)]
+    struct A {
+        a: u32,
+        b: u32,
+    }
+
+    fn repeat(input: &[u8], n: usize) -> Vec<u8> {
+        let mut output = vec![];
+
+        for _ in 0..n {
+            output.append(&mut input.to_vec());
+        }
+
+        output
+    }
+
+    #[test]
+    fn tree_hash_composite() {
+        let a = A { a: 0, b: 1 };
+
+        let fixed: FixedVector<A, U0> = FixedVector::from(vec![]);
+        assert_eq!(fixed.tree_hash_root(), merkle_root(&[0; 32], 0));
+
+        let fixed: FixedVector<A, U1> = FixedVector::from(vec![a]);
+        assert_eq!(fixed.tree_hash_root(), merkle_root(&a.tree_hash_root(), 0));
+
+        let fixed: FixedVector<A, U8> = FixedVector::from(vec![a; 8]);
+        assert_eq!(
+            fixed.tree_hash_root(),
+            merkle_root(&repeat(&a.tree_hash_root(), 8), 0)
+        );
+
+        let fixed: FixedVector<A, U13> = FixedVector::from(vec![a; 13]);
+        assert_eq!(
+            fixed.tree_hash_root(),
+            merkle_root(&repeat(&a.tree_hash_root(), 13), 0)
+        );
+
+        let fixed: FixedVector<A, U16> = FixedVector::from(vec![a; 16]);
+        assert_eq!(
+            fixed.tree_hash_root(),
+            merkle_root(&repeat(&a.tree_hash_root(), 16), 0)
+        );
+    }
+}

--- a/eth2/utils/ssz_types/src/fixed_vector.rs
+++ b/eth2/utils/ssz_types/src/fixed_vector.rs
@@ -1,5 +1,7 @@
 // Copied (potentially with slight modifications and deletions) from sigp/lighthouse
-
+// Copied from the file of the same name in the https://github.com/sigp/lighthouse repo with some
+// modifications and deletions.  Specifically, removed all code not needed for this repo and updated
+// the Encode implementation here to match the Encode trait of the eth2_ssz crate.
 use crate::tree_hash::vec_tree_hash_root;
 use crate::Error;
 use serde_derive::{Deserialize, Serialize};

--- a/eth2/utils/ssz_types/src/fixed_vector.rs
+++ b/eth2/utils/ssz_types/src/fixed_vector.rs
@@ -71,8 +71,8 @@ impl<T, N: Unsigned> FixedVector<T, N> {
 
     /// Create a new vector filled with clones of `elem`.
     pub fn from_elem(elem: T) -> Self
-        where
-            T: Clone,
+    where
+        T: Clone,
     {
         Self {
             vec: vec![elem; N::to_usize()],
@@ -149,8 +149,8 @@ impl<T, N: Unsigned> Deref for FixedVector<T, N> {
 }
 
 impl<T, N: Unsigned> tree_hash::TreeHash for FixedVector<T, N>
-    where
-        T: tree_hash::TreeHash,
+where
+    T: tree_hash::TreeHash,
 {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -170,8 +170,8 @@ impl<T, N: Unsigned> tree_hash::TreeHash for FixedVector<T, N>
 }
 
 impl<T, N: Unsigned> ssz::Encode for FixedVector<T, N>
-    where
-        T: ssz::Encode,
+where
+    T: ssz::Encode,
 {
     fn is_ssz_fixed_len() -> bool {
         T::is_ssz_fixed_len()
@@ -185,9 +185,9 @@ impl<T, N: Unsigned> ssz::Encode for FixedVector<T, N>
         }
     }
 
-//    fn ssz_bytes_len(&self) -> usize {
-//        self.vec.ssz_bytes_len()
-//    }
+    //    fn ssz_bytes_len(&self) -> usize {
+    //        self.vec.ssz_bytes_len()
+    //    }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
         if T::is_ssz_fixed_len() {
@@ -209,8 +209,8 @@ impl<T, N: Unsigned> ssz::Encode for FixedVector<T, N>
 }
 
 impl<T, N: Unsigned> ssz::Decode for FixedVector<T, N>
-    where
-        T: ssz::Decode + Default,
+where
+    T: ssz::Decode + Default,
 {
     fn is_ssz_fixed_len() -> bool {
         T::is_ssz_fixed_len()
@@ -324,7 +324,7 @@ mod test {
 
     fn ssz_round_trip<T: Encode + Decode + std::fmt::Debug + PartialEq>(item: T) {
         let encoded = &item.as_ssz_bytes();
-//        assert_eq!(item.ssz_bytes_len(), encoded.len());
+        //        assert_eq!(item.ssz_bytes_len(), encoded.len());
         assert_eq!(T::from_ssz_bytes(&encoded), Ok(item));
     }
 

--- a/eth2/utils/ssz_types/src/lib.rs
+++ b/eth2/utils/ssz_types/src/lib.rs
@@ -1,4 +1,6 @@
-// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+// Copied from the file of the same name in the https://github.com/sigp/lighthouse repo with some
+// modifications and deletions.  Specifically, removed all code not needed for this repo and updated
+// the Encode implementation here to match the Encode trait of the eth2_ssz crate.
 
 //! Provides types with unique properties required for SSZ serialization and Merklization:
 //!

--- a/eth2/utils/ssz_types/src/lib.rs
+++ b/eth2/utils/ssz_types/src/lib.rs
@@ -1,0 +1,73 @@
+// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+
+//! Provides types with unique properties required for SSZ serialization and Merklization:
+//!
+//! - `FixedVector`: A heap-allocated list with a size that is fixed at compile time.
+//! - `VariableList`: A heap-allocated list that cannot grow past a type-level maximum length.
+//! - `BitList`: A heap-allocated bitfield that with a type-level _maximum_ length.
+//! - `BitVector`: A heap-allocated bitfield that with a type-level _fixed__ length.
+//!
+//! These structs are required as SSZ serialization and Merklization rely upon type-level lengths
+//! for padding and verification.
+//!
+//! Adheres to the Ethereum 2.0 [SSZ
+//! specification](https://github.com/ethereum/eth2.0-specs/blob/v0.8.1/specs/simple-serialize.md)
+//! at v0.8.1 .
+//!
+//! ## Example
+//! ```
+//! use ssz_types::*;
+//!
+//! pub struct Example {
+//!     bit_vector: BitVector<typenum::U8>,
+//!     bit_list: BitList<typenum::U8>,
+//!     variable_list: VariableList<u64, typenum::U8>,
+//!     fixed_vector: FixedVector<u64, typenum::U8>,
+//! }
+//!
+//! let mut example = Example {
+//!     bit_vector: Bitfield::new(),
+//!     bit_list: Bitfield::with_capacity(4).unwrap(),
+//!     variable_list: <_>::from(vec![0, 1]),
+//!     fixed_vector: <_>::from(vec![2, 3]),
+//! };
+//!
+//! assert_eq!(example.bit_vector.len(), 8);
+//! assert_eq!(example.bit_list.len(), 4);
+//! assert_eq!(&example.variable_list[..], &[0, 1]);
+//! assert_eq!(&example.fixed_vector[..], &[2, 3, 0, 0, 0, 0, 0, 0]);
+//!
+//! ```
+
+#[macro_use]
+mod bitfield;
+mod fixed_vector;
+mod tree_hash;
+mod variable_list;
+
+pub use bitfield::{BitList, BitVector, Bitfield};
+pub use fixed_vector::FixedVector;
+pub use typenum;
+pub use variable_list::VariableList;
+
+pub mod length {
+    pub use crate::bitfield::{Fixed, Variable};
+}
+
+/// Returned when an item encounters an error.
+#[derive(PartialEq, Debug, Clone)]
+pub enum Error {
+    OutOfBounds {
+        i: usize,
+        len: usize,
+    },
+    /// A `BitList` does not have a set bit, therefore it's length is unknowable.
+    MissingLengthInformation,
+    /// A `BitList` has excess bits set to true.
+    ExcessBits,
+    /// A `BitList` has an invalid number of bytes for a given bit length.
+    InvalidByteCount {
+        given: usize,
+        expected: usize,
+    },
+}

--- a/eth2/utils/ssz_types/src/tree_hash.rs
+++ b/eth2/utils/ssz_types/src/tree_hash.rs
@@ -1,0 +1,50 @@
+// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+
+use tree_hash::{merkle_root, TreeHash, TreeHashType, BYTES_PER_CHUNK};
+use typenum::Unsigned;
+
+/// A helper function providing common functionality between the `TreeHash` implementations for
+/// `FixedVector` and `VariableList`.
+pub fn vec_tree_hash_root<T, N>(vec: &[T]) -> Vec<u8>
+    where
+        T: TreeHash,
+        N: Unsigned,
+{
+    let (leaves, minimum_chunk_count) = match T::tree_hash_type() {
+        TreeHashType::Basic => {
+            let mut leaves =
+                Vec::with_capacity((BYTES_PER_CHUNK / T::tree_hash_packing_factor()) * vec.len());
+
+            for item in vec {
+                leaves.append(&mut item.tree_hash_packed_encoding());
+            }
+
+            let values_per_chunk = T::tree_hash_packing_factor();
+            let minimum_chunk_count = (N::to_usize() + values_per_chunk - 1) / values_per_chunk;
+
+            (leaves, minimum_chunk_count)
+        }
+        TreeHashType::Container | TreeHashType::List | TreeHashType::Vector => {
+            let mut leaves = Vec::with_capacity(vec.len() * BYTES_PER_CHUNK);
+
+            for item in vec {
+                leaves.append(&mut item.tree_hash_root())
+            }
+
+            let minimum_chunk_count = N::to_usize();
+
+            (leaves, minimum_chunk_count)
+        }
+    };
+
+    merkle_root(&leaves, minimum_chunk_count)
+}
+
+/// A helper function providing common functionality for finding the Merkle root of some bytes that
+/// represent a bitfield.
+pub fn bitfield_bytes_tree_hash_root<N: Unsigned>(bytes: &[u8]) -> Vec<u8> {
+    let byte_size = (N::to_usize() + 7) / 8;
+    let minimum_chunk_count = (byte_size + BYTES_PER_CHUNK - 1) / BYTES_PER_CHUNK;
+
+    merkle_root(bytes, minimum_chunk_count)
+}

--- a/eth2/utils/ssz_types/src/tree_hash.rs
+++ b/eth2/utils/ssz_types/src/tree_hash.rs
@@ -6,9 +6,9 @@ use typenum::Unsigned;
 /// A helper function providing common functionality between the `TreeHash` implementations for
 /// `FixedVector` and `VariableList`.
 pub fn vec_tree_hash_root<T, N>(vec: &[T]) -> Vec<u8>
-    where
-        T: TreeHash,
-        N: Unsigned,
+where
+    T: TreeHash,
+    N: Unsigned,
 {
     let (leaves, minimum_chunk_count) = match T::tree_hash_type() {
         TreeHashType::Basic => {

--- a/eth2/utils/ssz_types/src/tree_hash.rs
+++ b/eth2/utils/ssz_types/src/tree_hash.rs
@@ -1,4 +1,4 @@
-// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+// Copied from the file of the same name in the https://github.com/sigp/lighthouse repo.
 
 use tree_hash::{merkle_root, TreeHash, TreeHashType, BYTES_PER_CHUNK};
 use typenum::Unsigned;

--- a/eth2/utils/ssz_types/src/variable_list.rs
+++ b/eth2/utils/ssz_types/src/variable_list.rs
@@ -1,4 +1,4 @@
-// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+// Copied from the file of the same name in the https://github.com/sigp/lighthouse repo.
 
 use crate::tree_hash::vec_tree_hash_root;
 use crate::Error;

--- a/eth2/utils/ssz_types/src/variable_list.rs
+++ b/eth2/utils/ssz_types/src/variable_list.rs
@@ -176,8 +176,8 @@ impl<'a, T, N: Unsigned> IntoIterator for &'a VariableList<T, N> {
 }
 
 impl<T, N: Unsigned> tree_hash::TreeHash for VariableList<T, N>
-    where
-        T: tree_hash::TreeHash,
+where
+    T: tree_hash::TreeHash,
 {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::List
@@ -199,8 +199,8 @@ impl<T, N: Unsigned> tree_hash::TreeHash for VariableList<T, N>
 }
 
 impl<T, N: Unsigned> ssz::Encode for VariableList<T, N>
-    where
-        T: ssz::Encode,
+where
+    T: ssz::Encode,
 {
     fn is_ssz_fixed_len() -> bool {
         <Vec<T>>::is_ssz_fixed_len()
@@ -210,9 +210,9 @@ impl<T, N: Unsigned> ssz::Encode for VariableList<T, N>
         <Vec<T>>::ssz_fixed_len()
     }
 
-//    fn ssz_bytes_len(&self) -> usize {
-//        self.vec.ssz_bytes_len()
-//    }
+    //    fn ssz_bytes_len(&self) -> usize {
+    //        self.vec.ssz_bytes_len()
+    //    }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
         self.vec.ssz_append(buf)
@@ -220,8 +220,8 @@ impl<T, N: Unsigned> ssz::Encode for VariableList<T, N>
 }
 
 impl<T, N: Unsigned> ssz::Decode for VariableList<T, N>
-    where
-        T: ssz::Decode,
+where
+    T: ssz::Decode,
 {
     fn is_ssz_fixed_len() -> bool {
         <Vec<T>>::is_ssz_fixed_len()
@@ -310,7 +310,7 @@ mod test {
 
     fn round_trip<T: Encode + Decode + std::fmt::Debug + PartialEq>(item: T) {
         let encoded = &item.as_ssz_bytes();
-//        assert_eq!(item.ssz_bytes_len(), encoded.len());
+        //        assert_eq!(item.ssz_bytes_len(), encoded.len());
         assert_eq!(T::from_ssz_bytes(&encoded), Ok(item));
     }
 

--- a/eth2/utils/ssz_types/src/variable_list.rs
+++ b/eth2/utils/ssz_types/src/variable_list.rs
@@ -1,0 +1,429 @@
+// Copied (potentially with slight modifications and deletions) from sigp/lighthouse
+
+use crate::tree_hash::vec_tree_hash_root;
+use crate::Error;
+use serde_derive::{Deserialize, Serialize};
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut, Index, IndexMut};
+use std::slice::SliceIndex;
+use typenum::Unsigned;
+
+pub use typenum;
+
+/// Emulates a SSZ `List`.
+///
+/// An ordered, heap-allocated, variable-length, homogeneous collection of `T`, with no more than
+/// `N` values.
+///
+/// This struct is backed by a Rust `Vec` but constrained such that it must be instantiated with a
+/// fixed number of elements and you may not add or remove elements, only modify.
+///
+/// The length of this struct is fixed at the type-level using
+/// [typenum](https://crates.io/crates/typenum).
+///
+/// ## Example
+///
+/// ```
+/// use ssz_types::{VariableList, typenum};
+///
+/// let base: Vec<u64> = vec![1, 2, 3, 4];
+///
+/// // Create a `VariableList` from a `Vec` that has the expected length.
+/// let exact: VariableList<_, typenum::U4> = VariableList::from(base.clone());
+/// assert_eq!(&exact[..], &[1, 2, 3, 4]);
+///
+/// // Create a `VariableList` from a `Vec` that is too long and the `Vec` is truncated.
+/// let short: VariableList<_, typenum::U3> = VariableList::from(base.clone());
+/// assert_eq!(&short[..], &[1, 2, 3]);
+///
+/// // Create a `VariableList` from a `Vec` that is shorter than the maximum.
+/// let mut long: VariableList<_, typenum::U5> = VariableList::from(base);
+/// assert_eq!(&long[..], &[1, 2, 3, 4]);
+///
+/// // Push a value to if it does not exceed the maximum
+/// long.push(5).unwrap();
+/// assert_eq!(&long[..], &[1, 2, 3, 4, 5]);
+///
+/// // Push a value to if it _does_ exceed the maximum.
+/// assert!(long.push(6).is_err());
+/// ```
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct VariableList<T, N> {
+    vec: Vec<T>,
+    _phantom: PhantomData<N>,
+}
+
+impl<T, N: Unsigned> VariableList<T, N> {
+    /// Returns `Some` if the given `vec` equals the fixed length of `Self`. Otherwise returns
+    /// `None`.
+    pub fn new(vec: Vec<T>) -> Result<Self, Error> {
+        if vec.len() <= N::to_usize() {
+            Ok(Self {
+                vec,
+                _phantom: PhantomData,
+            })
+        } else {
+            Err(Error::OutOfBounds {
+                i: vec.len(),
+                len: Self::max_len(),
+            })
+        }
+    }
+
+    /// Create an empty list.
+    pub fn empty() -> Self {
+        Self {
+            vec: vec![],
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Returns the number of values presently in `self`.
+    pub fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    /// True if `self` does not contain any values.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the type-level maximum length.
+    pub fn max_len() -> usize {
+        N::to_usize()
+    }
+
+    /// Appends `value` to the back of `self`.
+    ///
+    /// Returns `Err(())` when appending `value` would exceed the maximum length.
+    pub fn push(&mut self, value: T) -> Result<(), Error> {
+        if self.vec.len() < Self::max_len() {
+            self.vec.push(value);
+            Ok(())
+        } else {
+            Err(Error::OutOfBounds {
+                i: self.vec.len() + 1,
+                len: Self::max_len(),
+            })
+        }
+    }
+}
+
+impl<T, N: Unsigned> From<Vec<T>> for VariableList<T, N> {
+    fn from(mut vec: Vec<T>) -> Self {
+        vec.truncate(N::to_usize());
+
+        Self {
+            vec,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, N: Unsigned> Into<Vec<T>> for VariableList<T, N> {
+    fn into(self) -> Vec<T> {
+        self.vec
+    }
+}
+
+impl<T, N: Unsigned> Default for VariableList<T, N> {
+    fn default() -> Self {
+        Self {
+            vec: Vec::default(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, N: Unsigned, I: SliceIndex<[T]>> Index<I> for VariableList<T, N> {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        Index::index(&self.vec, index)
+    }
+}
+
+impl<T, N: Unsigned, I: SliceIndex<[T]>> IndexMut<I> for VariableList<T, N> {
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        IndexMut::index_mut(&mut self.vec, index)
+    }
+}
+
+impl<T, N: Unsigned> Deref for VariableList<T, N> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        &self.vec[..]
+    }
+}
+
+impl<T, N: Unsigned> DerefMut for VariableList<T, N> {
+    fn deref_mut(&mut self) -> &mut [T] {
+        &mut self.vec[..]
+    }
+}
+
+impl<'a, T, N: Unsigned> IntoIterator for &'a VariableList<T, N> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<T, N: Unsigned> tree_hash::TreeHash for VariableList<T, N>
+    where
+        T: tree_hash::TreeHash,
+{
+    fn tree_hash_type() -> tree_hash::TreeHashType {
+        tree_hash::TreeHashType::List
+    }
+
+    fn tree_hash_packed_encoding(&self) -> Vec<u8> {
+        unreachable!("List should never be packed.")
+    }
+
+    fn tree_hash_packing_factor() -> usize {
+        unreachable!("List should never be packed.")
+    }
+
+    fn tree_hash_root(&self) -> Vec<u8> {
+        let root = vec_tree_hash_root::<T, N>(&self.vec);
+
+        tree_hash::mix_in_length(&root, self.len())
+    }
+}
+
+impl<T, N: Unsigned> ssz::Encode for VariableList<T, N>
+    where
+        T: ssz::Encode,
+{
+    fn is_ssz_fixed_len() -> bool {
+        <Vec<T>>::is_ssz_fixed_len()
+    }
+
+    fn ssz_fixed_len() -> usize {
+        <Vec<T>>::ssz_fixed_len()
+    }
+
+//    fn ssz_bytes_len(&self) -> usize {
+//        self.vec.ssz_bytes_len()
+//    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        self.vec.ssz_append(buf)
+    }
+}
+
+impl<T, N: Unsigned> ssz::Decode for VariableList<T, N>
+    where
+        T: ssz::Decode,
+{
+    fn is_ssz_fixed_len() -> bool {
+        <Vec<T>>::is_ssz_fixed_len()
+    }
+
+    fn ssz_fixed_len() -> usize {
+        <Vec<T>>::ssz_fixed_len()
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        let vec = <Vec<T>>::from_ssz_bytes(bytes)?;
+
+        Self::new(vec).map_err(|e| ssz::DecodeError::BytesInvalid(format!("VariableList {:?}", e)))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ssz::*;
+    use tree_hash::{merkle_root, TreeHash};
+    use tree_hash_derive::TreeHash;
+    use typenum::*;
+
+    #[test]
+    fn new() {
+        let vec = vec![42; 5];
+        let fixed: Result<VariableList<u64, U4>, _> = VariableList::new(vec.clone());
+        assert!(fixed.is_err());
+
+        let vec = vec![42; 3];
+        let fixed: Result<VariableList<u64, U4>, _> = VariableList::new(vec.clone());
+        assert!(fixed.is_ok());
+
+        let vec = vec![42; 4];
+        let fixed: Result<VariableList<u64, U4>, _> = VariableList::new(vec.clone());
+        assert!(fixed.is_ok());
+    }
+
+    #[test]
+    fn indexing() {
+        let vec = vec![1, 2];
+
+        let mut fixed: VariableList<u64, U8192> = vec.clone().into();
+
+        assert_eq!(fixed[0], 1);
+        assert_eq!(&fixed[0..1], &vec[0..1]);
+        assert_eq!((&fixed[..]).len(), 2);
+
+        fixed[1] = 3;
+        assert_eq!(fixed[1], 3);
+    }
+
+    #[test]
+    fn length() {
+        let vec = vec![42; 5];
+        let fixed: VariableList<u64, U4> = VariableList::from(vec.clone());
+        assert_eq!(&fixed[..], &vec[0..4]);
+
+        let vec = vec![42; 3];
+        let fixed: VariableList<u64, U4> = VariableList::from(vec.clone());
+        assert_eq!(&fixed[0..3], &vec[..]);
+        assert_eq!(&fixed[..], &vec![42, 42, 42][..]);
+
+        let vec = vec![];
+        let fixed: VariableList<u64, U4> = VariableList::from(vec.clone());
+        assert_eq!(&fixed[..], &vec![][..]);
+    }
+
+    #[test]
+    fn deref() {
+        let vec = vec![0, 2, 4, 6];
+        let fixed: VariableList<u64, U4> = VariableList::from(vec);
+
+        assert_eq!(fixed.get(0), Some(&0));
+        assert_eq!(fixed.get(3), Some(&6));
+        assert_eq!(fixed.get(4), None);
+    }
+
+    #[test]
+    fn encode() {
+        let vec: VariableList<u16, U2> = vec![0; 2].into();
+        assert_eq!(vec.as_ssz_bytes(), vec![0, 0, 0, 0]);
+        assert_eq!(<VariableList<u16, U2> as Encode>::ssz_fixed_len(), 4);
+    }
+
+    fn round_trip<T: Encode + Decode + std::fmt::Debug + PartialEq>(item: T) {
+        let encoded = &item.as_ssz_bytes();
+//        assert_eq!(item.ssz_bytes_len(), encoded.len());
+        assert_eq!(T::from_ssz_bytes(&encoded), Ok(item));
+    }
+
+    #[test]
+    fn u16_len_8() {
+        round_trip::<VariableList<u16, U8>>(vec![42; 8].into());
+        round_trip::<VariableList<u16, U8>>(vec![0; 8].into());
+    }
+
+    fn root_with_length(bytes: &[u8], len: usize) -> Vec<u8> {
+        let root = merkle_root(bytes, 0);
+        tree_hash::mix_in_length(&root, len)
+    }
+
+    #[test]
+    fn tree_hash_u8() {
+        let fixed: VariableList<u8, U0> = VariableList::from(vec![]);
+        assert_eq!(fixed.tree_hash_root(), root_with_length(&[0; 8], 0));
+
+        for i in 0..=1 {
+            let fixed: VariableList<u8, U1> = VariableList::from(vec![0; i]);
+            assert_eq!(fixed.tree_hash_root(), root_with_length(&vec![0; i], i));
+        }
+
+        for i in 0..=8 {
+            let fixed: VariableList<u8, U8> = VariableList::from(vec![0; i]);
+            assert_eq!(fixed.tree_hash_root(), root_with_length(&vec![0; i], i));
+        }
+
+        for i in 0..=13 {
+            let fixed: VariableList<u8, U13> = VariableList::from(vec![0; i]);
+            assert_eq!(fixed.tree_hash_root(), root_with_length(&vec![0; i], i));
+        }
+
+        for i in 0..=16 {
+            let fixed: VariableList<u8, U16> = VariableList::from(vec![0; i]);
+            assert_eq!(fixed.tree_hash_root(), root_with_length(&vec![0; i], i));
+        }
+
+        let source: Vec<u8> = (0..16).collect();
+        let fixed: VariableList<u8, U16> = VariableList::from(source.clone());
+        assert_eq!(fixed.tree_hash_root(), root_with_length(&source, 16));
+    }
+
+    #[derive(Clone, Copy, TreeHash, Default)]
+    struct A {
+        a: u32,
+        b: u32,
+    }
+
+    fn repeat(input: &[u8], n: usize) -> Vec<u8> {
+        let mut output = vec![];
+
+        for _ in 0..n {
+            output.append(&mut input.to_vec());
+        }
+
+        output
+    }
+
+    fn padded_root_with_length(bytes: &[u8], len: usize, min_nodes: usize) -> Vec<u8> {
+        let root = merkle_root(bytes, min_nodes);
+        tree_hash::mix_in_length(&root, len)
+    }
+
+    #[test]
+    fn tree_hash_composite() {
+        let a = A { a: 0, b: 1 };
+
+        let fixed: VariableList<A, U0> = VariableList::from(vec![]);
+        assert_eq!(
+            fixed.tree_hash_root(),
+            padded_root_with_length(&[0; 32], 0, 0),
+        );
+
+        for i in 0..=1 {
+            let fixed: VariableList<A, U1> = VariableList::from(vec![a; i]);
+            assert_eq!(
+                fixed.tree_hash_root(),
+                padded_root_with_length(&repeat(&a.tree_hash_root(), i), i, 1),
+                "U1 {}",
+                i
+            );
+        }
+
+        for i in 0..=8 {
+            let fixed: VariableList<A, U8> = VariableList::from(vec![a; i]);
+            assert_eq!(
+                fixed.tree_hash_root(),
+                padded_root_with_length(&repeat(&a.tree_hash_root(), i), i, 8),
+                "U8 {}",
+                i
+            );
+        }
+
+        for i in 0..=13 {
+            let fixed: VariableList<A, U13> = VariableList::from(vec![a; i]);
+            assert_eq!(
+                fixed.tree_hash_root(),
+                padded_root_with_length(&repeat(&a.tree_hash_root(), i), i, 13),
+                "U13 {}",
+                i
+            );
+        }
+
+        for i in 0..=16 {
+            let fixed: VariableList<A, U16> = VariableList::from(vec![a; i]);
+            assert_eq!(
+                fixed.tree_hash_root(),
+                padded_root_with_length(&repeat(&a.tree_hash_root(), i), i, 16),
+                "U16 {}",
+                i
+            );
+        }
+    }
+}

--- a/notion-server/Cargo.toml
+++ b/notion-server/Cargo.toml
@@ -12,14 +12,17 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.11.0"
+ewasm = "0.2.2"
+futures-util = "0.3.1"
+# Rocket depends on an older version of `cookie`, which depends on an older
+# version of `ring`, which conflicts with the newer version required in other packages
+# Disabling cookie support addresses this issue.
+rocket = { version= "0.4.2", default-features=false }
+rocket_contrib = "0.4.2"
+serde = { version = "1.0", features = ["derive"] }
 snafu = "0.6.0"
 structopt = "0.3.4"
 tokio = { version = "0.2.0", features = ["sync", "io-util", "rt-core", "blocking", "macros"] }
-rocket = "0.4.2"
-rocket_contrib = "0.4.2"
-futures-util = "0.3.1"
-ewasm = "0.2.2"
-serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 hex = "0.4.0"

--- a/notion-server/Cargo.toml
+++ b/notion-server/Cargo.toml
@@ -16,7 +16,7 @@ ewasm = "0.2.2"
 futures-util = "0.3.1"
 # Rocket depends on an older version of `cookie`, which depends on an older
 # version of `ring`, which conflicts with the newer version required in other packages
-# Disabling cookie support addresses this issue.
+# Disabling cookie support with `default-features=false` avoids this issue.
 rocket = { version= "0.4.2", default-features=false }
 rocket_contrib = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Originally, this simulation's MVP was built based on very simple, non-spec-compliant representations of eth2 state.  This diff begins the process of migrating to spec-compliant representations of state.

All added logic is based heavily on the spec-compliant (and very thorough) stuff found in the [sigp/lighthouse repo](https://github.com/sigp/lighthouse).  This simulation does not intend to be a fully spec-compliant Eth2 node (which I believe is lighthouse's goal), but it does intend to be spec-compliant for all eth2 structs, and to (long term) approximate the behavior of an Eth2 beacon chain + shard chains.

This diff adds:
* `BeaconState`
* `ExecutionEnvironment`
* `CrossLink`
* supporting logic to make the above structs spec-compliant
* supporting logic to make the above structs SSZ-serializable

Future diffs will address the following (not necessarily in this order):
* Add additional spec-compliant types as necessary
* Add the external-facing methods defined in the [roadmap](https://github.com/quilt/simulation/issues/21) where they don't already exist
* Hook up the new spec-compliant types to the internal state of the simulation, remove the "old" non-spec-compliant representations.
  * (internal state of the simulation may not exactly mirror the spec, but all specced representations (eg. `BeaconState`, `BeaconBlock`, etc) should be spec-compliant)
* Add merkleization support for Eth2 types
* Eventually add more true-to-life simulation under the hood (eg. creating blocks and transitioning state of `BeaconState` as a result of incoming blocks vs. just having `BeaconState`)